### PR TITLE
chore: refresh OpenDexter release descriptor

### DIFF
--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -189,7 +189,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-marketplace-search-8d945e6c",
+          "resourceUri": "ui://dexter/x402-marketplace-search-f219b145",
           "visibility": [
             "model",
             "app"
@@ -209,8 +209,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-marketplace-search-8d945e6c",
-        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-8d945e6c",
+        "ui/resourceUri": "ui://dexter/x402-marketplace-search-f219b145",
+        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-f219b145",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",


### PR DESCRIPTION
Refresh the x402 search widget URI after the ranking-health asset build so the immutable OpenDexter release builder can prove the committed descriptor against the archived source.\n\nVerification: source-owned materializer completed against the pinned API and facilitator contract commits.