### PR TITLE
chore: repin OpenDexter hosted sources

### DIFF
--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -16,15 +16,15 @@
     },
     "integratedApiRelease": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "6d8de2cee71fc217559fa2a2825fa2a25faf9497",
-      "tree": "a8f7a84e001bcd06f0418eb149da4e14fbafbfeb",
+      "commit": "1f21c228fbbbd8a7a7bc0e67b4ade734eb8719d5",
+      "tree": "dce42559464ab5eff3c1113c983affac33242d77",
       "governedContractCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
       "governedContractTree": "b8a3bdd790379f82b959663e679960f213addb5b"
     },
     "portfolioProjection": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "6d8de2cee71fc217559fa2a2825fa2a25faf9497",
-      "tree": "a8f7a84e001bcd06f0418eb149da4e14fbafbfeb",
+      "commit": "1f21c228fbbbd8a7a7bc0e67b4ade734eb8719d5",
+      "tree": "dce42559464ab5eff3c1113c983affac33242d77",
       "sourcePaths": [
         "src/portfolio/approvedActionTargets.ts",
         "src/routes/passkeyMcpBinding.ts",
@@ -39,8 +39,8 @@
     },
     "facilitator": {
       "repository": "https://github.com/Dexter-DAO/dexter-facilitator",
-      "commit": "df370826b7b951dfc825a689c4e6f3b1928ee5e2",
-      "tree": "a9b4b18eb350143f3265834571c910891c83dd5c",
+      "commit": "801547315a59a48fc8dcb4d3e42e40c2ee5ac09e",
+      "tree": "5f54c0c08eb004e4e8d810abccdaefaa2d7f7898",
       "bindingFixture": {
         "consumerPath": "tests/fixtures/governed-agent-trade-api-facilitator-binding-v1.json",
         "apiPath": "tests/fixtures/governed-agent-trade-api-facilitator-binding-v1.json",

--- a/release/opendexter-source-contracts.json
+++ b/release/opendexter-source-contracts.json
@@ -13,15 +13,15 @@
   },
   "integratedApiRelease": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "6d8de2cee71fc217559fa2a2825fa2a25faf9497",
-    "tree": "a8f7a84e001bcd06f0418eb149da4e14fbafbfeb",
+    "commit": "1f21c228fbbbd8a7a7bc0e67b4ade734eb8719d5",
+    "tree": "dce42559464ab5eff3c1113c983affac33242d77",
     "governedContractCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
     "governedContractTree": "b8a3bdd790379f82b959663e679960f213addb5b"
   },
   "portfolioProjection": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "6d8de2cee71fc217559fa2a2825fa2a25faf9497",
-    "tree": "a8f7a84e001bcd06f0418eb149da4e14fbafbfeb",
+    "commit": "1f21c228fbbbd8a7a7bc0e67b4ade734eb8719d5",
+    "tree": "dce42559464ab5eff3c1113c983affac33242d77",
     "sourcePaths": [
       "src/portfolio/approvedActionTargets.ts",
       "src/routes/passkeyMcpBinding.ts",
@@ -36,8 +36,8 @@
   },
   "facilitator": {
     "repository": "https://github.com/Dexter-DAO/dexter-facilitator",
-    "commit": "df370826b7b951dfc825a689c4e6f3b1928ee5e2",
-    "tree": "a9b4b18eb350143f3265834571c910891c83dd5c",
+    "commit": "801547315a59a48fc8dcb4d3e42e40c2ee5ac09e",
+    "tree": "5f54c0c08eb004e4e8d810abccdaefaa2d7f7898",
     "bindingFixture": {
       "consumerPath": "tests/fixtures/governed-agent-trade-api-facilitator-binding-v1.json",
       "apiPath": "tests/fixtures/governed-agent-trade-api-facilitator-binding-v1.json",

--- a/scripts/materialize-open-tool-descriptors.mjs
+++ b/scripts/materialize-open-tool-descriptors.mjs
@@ -103,14 +103,14 @@ const EXPECTED_SOURCE_CONTRACTS = Object.freeze({
     '449fc6b5a253d6856ae9f0990932dc6cefb84871c981229afb603a6314efa798',
   apiCanonicalBodyDigest:
     '48e77a936f06fe07b66fee7c2cb9126e8305d4e180c2c304513d5f0ea1636e16',
-  integratedApiCommit: '6d8de2cee71fc217559fa2a2825fa2a25faf9497',
-  integratedApiTree: 'a8f7a84e001bcd06f0418eb149da4e14fbafbfeb',
+  integratedApiCommit: '1f21c228fbbbd8a7a7bc0e67b4ade734eb8719d5',
+  integratedApiTree: 'dce42559464ab5eff3c1113c983affac33242d77',
   portfolioProjectionFixtureSha256:
     '9c4c29b0d911b490d53a375eca1ae302501397be9c56250591bafaeb34a4e625',
   portfolioProjectionCanonicalDigest:
     'f4a3f826aa1c08531d42da402f08df709642ea75a84fd74608be75cdba2fc28a',
-  facilitatorCommit: 'df370826b7b951dfc825a689c4e6f3b1928ee5e2',
-  facilitatorTree: 'a9b4b18eb350143f3265834571c910891c83dd5c',
+  facilitatorCommit: '801547315a59a48fc8dcb4d3e42e40c2ee5ac09e',
+  facilitatorTree: '5f54c0c08eb004e4e8d810abccdaefaa2d7f7898',
   bindingFixtureSha256:
     '66bbd343637fe9b3af245b2ace823a9dff1d8032e2dd01da7ee4bd71cc1ff7d6',
   mcpCommit: '0647bbdf081733ac3ca5ba82850c2c1db79307cb',

--- a/tests/open-tool-descriptors.test.mjs
+++ b/tests/open-tool-descriptors.test.mjs
@@ -404,15 +404,15 @@ test('source materializer emits one deterministic full hosted descriptor', async
   );
   assert.deepEqual(descriptor.sourceContracts.integratedApiRelease, {
     repository: 'https://github.com/Dexter-DAO/dexter-api',
-    commit: '6d8de2cee71fc217559fa2a2825fa2a25faf9497',
-    tree: 'a8f7a84e001bcd06f0418eb149da4e14fbafbfeb',
+    commit: '1f21c228fbbbd8a7a7bc0e67b4ade734eb8719d5',
+    tree: 'dce42559464ab5eff3c1113c983affac33242d77',
     governedContractCommit: 'c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b',
     governedContractTree: 'b8a3bdd790379f82b959663e679960f213addb5b',
   });
   assert.deepEqual(descriptor.sourceContracts.portfolioProjection, {
     repository: 'https://github.com/Dexter-DAO/dexter-api',
-    commit: '6d8de2cee71fc217559fa2a2825fa2a25faf9497',
-    tree: 'a8f7a84e001bcd06f0418eb149da4e14fbafbfeb',
+    commit: '1f21c228fbbbd8a7a7bc0e67b4ade734eb8719d5',
+    tree: 'dce42559464ab5eff3c1113c983affac33242d77',
     sourcePaths: [
       'src/portfolio/approvedActionTargets.ts',
       'src/routes/passkeyMcpBinding.ts',
@@ -431,11 +431,11 @@ test('source materializer emits one deterministic full hosted descriptor', async
   });
   assert.equal(
     descriptor.sourceContracts.facilitator.commit,
-    'df370826b7b951dfc825a689c4e6f3b1928ee5e2',
+    '801547315a59a48fc8dcb4d3e42e40c2ee5ac09e',
   );
   assert.equal(
     descriptor.sourceContracts.facilitator.tree,
-    'a9b4b18eb350143f3265834571c910891c83dd5c',
+    '5f54c0c08eb004e4e8d810abccdaefaa2d7f7898',
   );
   assert.equal(
     descriptor.sourceContracts.facilitator.bindingFixture.sha256,


### PR DESCRIPTION
Repins the hosted OpenDexter source contract to the exact release inputs now intended for production:

- Dexter API `1f21c228fbbbd8a7a7bc0e67b4ade734eb8719d5` / tree `dce42559464ab5eff3c1113c983affac33242d77`
- Dexter Facilitator `801547315a59a48fc8dcb4d3e42e40c2ee5ac09e` / tree `5f54c0c08eb004e4e8d810abccdaefaa2d7f7898`

The descriptor was regenerated through the sterile archived materializer with both exact source roots and then independently rechecked from the advertised final commit.

Verification:
- `node --test tests/open-source-contracts.test.mjs tests/open-tool-descriptors.test.mjs` — 34 pass
- `node --test tests/*.test.mjs` — 551 pass, 1 skip
- `npm run verify:open-tool-descriptors` with exact API/facilitator roots — pass

No deployment or payment was performed.