### PR TITLE
feat: bind hosted tools to accepted production

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ checkout files and ignored `node_modules` are never descriptor evidence.
 
 Use `npm run build:apps-sdk:local` for a non-deploying widget build.
 `build:apps-sdk` retains its release behavior and copies served assets.
+After the API and facilitator releases have been accepted in production, freeze
+their advertised immutable identities and regenerate the hosted derivatives in
+one step:
+
+```bash
+npm run prepare:open-accepted-production
+```
+
+Preparation reads `https://api.dexter.cash/health` and
+`https://x402.dexter.cash/version` exactly once each. It writes the generated
+`release/opendexter-accepted-production.json` receipt, derives the existing
+public `sourceContracts/v3` projection from that receipt, and regenerates the
+hosted descriptor. Release verification, construction, and activation read
+only those frozen files; they never resolve mutable production endpoints.
 Construct a sealed candidate from the current clean, canonical Git commit into
 an explicit trusted release root without activating it:
 

--- a/lib/open-accepted-production-receipt.mjs
+++ b/lib/open-accepted-production-receipt.mjs
@@ -1,0 +1,295 @@
+import { chmod, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+export const OPENDEXTER_ACCEPTED_PRODUCTION_KIND =
+  'opendexter-accepted-production-receipt/v1';
+export const OPENDEXTER_API_HEALTH_ENDPOINT =
+  'https://api.dexter.cash/health';
+export const OPENDEXTER_FACILITATOR_VERSION_ENDPOINT =
+  'https://x402.dexter.cash/version';
+export const OPENDEXTER_API_REPOSITORY =
+  'https://github.com/Dexter-DAO/dexter-api';
+export const OPENDEXTER_FACILITATOR_REPOSITORY =
+  'https://github.com/Dexter-DAO/dexter-facilitator';
+
+const HEX_40 = /^[0-9a-f]{40}$/;
+const HEX_64 = /^[0-9a-f]{64}$/;
+const MAX_ADVERTISEMENT_BYTES = 64 * 1024;
+
+function exactKeys(value, expected) {
+  return value
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && JSON.stringify(Object.keys(value).sort())
+      === JSON.stringify([...expected].sort());
+}
+
+function requireHex(value, expression, label) {
+  if (typeof value !== 'string' || !expression.test(value)) {
+    throw new Error(`OpenDexter accepted production ${label} is invalid`);
+  }
+  return value;
+}
+
+function projectApiAdvertisement(advertisement) {
+  const release = advertisement?.release;
+  if (
+    advertisement?.ok !== true
+    || advertisement?.service !== 'dexter-api'
+    || release?.mode !== 'immutable-release'
+  ) {
+    throw new Error('OpenDexter accepted production API advertisement is invalid');
+  }
+  const sourceCommit = requireHex(
+    release.sourceCommit,
+    HEX_40,
+    'API source commit',
+  );
+  const sourceTree = requireHex(
+    release.sourceTree,
+    HEX_40,
+    'API source tree',
+  );
+  const toolingCommit = requireHex(
+    release.toolingCommit,
+    HEX_40,
+    'API tooling commit',
+  );
+  const artifactSha256 = requireHex(
+    release.artifactSha256,
+    HEX_64,
+    'API artifact digest',
+  );
+  const metadataBindingSha256 = requireHex(
+    release.metadataBindingSha256,
+    HEX_64,
+    'API metadata binding digest',
+  );
+  if (
+    typeof release.releaseId !== 'string'
+    || !release.releaseId.startsWith(
+      `${sourceCommit.slice(0, 12)}-${artifactSha256.slice(0, 16)}-`,
+    )
+    || !/^[0-9a-f-]+$/.test(release.releaseId)
+  ) {
+    throw new Error('OpenDexter accepted production API release ID is invalid');
+  }
+  return Object.freeze({
+    endpoint: OPENDEXTER_API_HEALTH_ENDPOINT,
+    repository: OPENDEXTER_API_REPOSITORY,
+    releaseId: release.releaseId,
+    sourceCommit,
+    sourceTree,
+    toolingCommit,
+    artifactSha256,
+    metadataBindingSha256,
+  });
+}
+
+function projectFacilitatorAdvertisement(advertisement) {
+  const release = advertisement?.release;
+  if (
+    advertisement?.identitySource !== 'release-provenance'
+    || release?.namespace !== 'dexter-facilitator-immutable-release/v1'
+  ) {
+    throw new Error(
+      'OpenDexter accepted production facilitator advertisement is invalid',
+    );
+  }
+  const sourceCommit = requireHex(
+    release.sourceCommit,
+    HEX_40,
+    'facilitator source commit',
+  );
+  if (advertisement.commit !== sourceCommit) {
+    throw new Error(
+      'OpenDexter accepted production facilitator commit is inconsistent',
+    );
+  }
+  return Object.freeze({
+    endpoint: OPENDEXTER_FACILITATOR_VERSION_ENDPOINT,
+    repository: OPENDEXTER_FACILITATOR_REPOSITORY,
+    namespace: release.namespace,
+    sourceCommit,
+    sourceTree: requireHex(
+      release.sourceTree,
+      HEX_40,
+      'facilitator source tree',
+    ),
+    sourceArchiveSha256: requireHex(
+      release.sourceArchiveSha256,
+      HEX_64,
+      'facilitator source archive digest',
+    ),
+    artifactSha256: requireHex(
+      release.artifactSha256,
+      HEX_64,
+      'facilitator artifact digest',
+    ),
+    artifactBindingDigest: requireHex(
+      release.artifactBindingDigest,
+      HEX_64,
+      'facilitator artifact binding digest',
+    ),
+    metadataBindingDigest: requireHex(
+      release.metadataBindingDigest,
+      HEX_64,
+      'facilitator metadata binding digest',
+    ),
+  });
+}
+
+export function createOpenDexterAcceptedProductionReceipt({
+  apiAdvertisement,
+  facilitatorAdvertisement,
+} = {}) {
+  const receipt = {
+    schemaVersion: 1,
+    kind: OPENDEXTER_ACCEPTED_PRODUCTION_KIND,
+    api: projectApiAdvertisement(apiAdvertisement),
+    facilitator: projectFacilitatorAdvertisement(facilitatorAdvertisement),
+  };
+  return Object.freeze(verifyOpenDexterAcceptedProductionReceipt(receipt));
+}
+
+export function verifyOpenDexterAcceptedProductionReceipt(receipt) {
+  if (
+    !exactKeys(receipt, ['schemaVersion', 'kind', 'api', 'facilitator'])
+    || receipt.schemaVersion !== 1
+    || receipt.kind !== OPENDEXTER_ACCEPTED_PRODUCTION_KIND
+    || !exactKeys(receipt.api, [
+      'endpoint',
+      'repository',
+      'releaseId',
+      'sourceCommit',
+      'sourceTree',
+      'toolingCommit',
+      'artifactSha256',
+      'metadataBindingSha256',
+    ])
+    || receipt.api.endpoint !== OPENDEXTER_API_HEALTH_ENDPOINT
+    || receipt.api.repository !== OPENDEXTER_API_REPOSITORY
+    || !HEX_40.test(receipt.api.sourceCommit ?? '')
+    || !HEX_40.test(receipt.api.sourceTree ?? '')
+    || !HEX_40.test(receipt.api.toolingCommit ?? '')
+    || !HEX_64.test(receipt.api.artifactSha256 ?? '')
+    || !HEX_64.test(receipt.api.metadataBindingSha256 ?? '')
+    || typeof receipt.api.releaseId !== 'string'
+    || !receipt.api.releaseId.startsWith(
+      `${receipt.api.sourceCommit.slice(0, 12)}-`
+        + `${receipt.api.artifactSha256.slice(0, 16)}-`,
+    )
+    || !/^[0-9a-f-]+$/.test(receipt.api.releaseId)
+    || !exactKeys(receipt.facilitator, [
+      'endpoint',
+      'repository',
+      'namespace',
+      'sourceCommit',
+      'sourceTree',
+      'sourceArchiveSha256',
+      'artifactSha256',
+      'artifactBindingDigest',
+      'metadataBindingDigest',
+    ])
+    || receipt.facilitator.endpoint
+      !== OPENDEXTER_FACILITATOR_VERSION_ENDPOINT
+    || receipt.facilitator.repository
+      !== OPENDEXTER_FACILITATOR_REPOSITORY
+    || receipt.facilitator.namespace
+      !== 'dexter-facilitator-immutable-release/v1'
+    || !HEX_40.test(receipt.facilitator.sourceCommit ?? '')
+    || !HEX_40.test(receipt.facilitator.sourceTree ?? '')
+    || !HEX_64.test(receipt.facilitator.sourceArchiveSha256 ?? '')
+    || !HEX_64.test(receipt.facilitator.artifactSha256 ?? '')
+    || !HEX_64.test(receipt.facilitator.artifactBindingDigest ?? '')
+    || !HEX_64.test(receipt.facilitator.metadataBindingDigest ?? '')
+  ) {
+    throw new Error('OpenDexter accepted production receipt is invalid');
+  }
+  return receipt;
+}
+
+async function fetchJsonAdvertisement({ endpoint, fetchImpl }) {
+  let response;
+  try {
+    response = await fetchImpl(endpoint, {
+      headers: { accept: 'application/json' },
+      redirect: 'error',
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (error) {
+    throw new Error(`OpenDexter production advertisement is unreachable: ${endpoint}`, {
+      cause: error,
+    });
+  }
+  if (
+    response?.ok !== true
+    || response.status !== 200
+    || (typeof response.url === 'string'
+      && response.url.length > 0
+      && response.url !== endpoint)
+  ) {
+    throw new Error(`OpenDexter production advertisement is invalid: ${endpoint}`);
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_ADVERTISEMENT_BYTES) {
+    throw new Error(`OpenDexter production advertisement is oversized: ${endpoint}`);
+  }
+  try {
+    return JSON.parse(bytes.toString('utf8'));
+  } catch (error) {
+    throw new Error(`OpenDexter production advertisement is not JSON: ${endpoint}`, {
+      cause: error,
+    });
+  }
+}
+
+/**
+ * Resolve each mutable production advertisement exactly once. The returned
+ * receipt contains only stable immutable-release identities, so retrying the
+ * preparation against the same accepted releases produces identical bytes.
+ */
+export async function resolveOpenDexterAcceptedProduction({
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('OpenDexter accepted production fetch implementation is absent');
+  }
+  const [apiAdvertisement, facilitatorAdvertisement] = await Promise.all([
+    fetchJsonAdvertisement({
+      endpoint: OPENDEXTER_API_HEALTH_ENDPOINT,
+      fetchImpl,
+    }),
+    fetchJsonAdvertisement({
+      endpoint: OPENDEXTER_FACILITATOR_VERSION_ENDPOINT,
+      fetchImpl,
+    }),
+  ]);
+  return createOpenDexterAcceptedProductionReceipt({
+    apiAdvertisement,
+    facilitatorAdvertisement,
+  });
+}
+
+export function serializeOpenDexterAcceptedProductionReceipt(receipt) {
+  verifyOpenDexterAcceptedProductionReceipt(receipt);
+  return `${JSON.stringify(receipt, null, 2)}\n`;
+}
+
+export async function writeFileAtomically(path, bytes) {
+  const target = resolve(path);
+  const temporary = resolve(
+    dirname(target),
+    `.${target.split('/').at(-1)}.${process.pid}.`
+      + `${randomBytes(8).toString('hex')}.tmp`,
+  );
+  try {
+    await writeFile(temporary, bytes, { flag: 'wx', mode: 0o644 });
+    await chmod(temporary, 0o644);
+    await rename(temporary, target);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+  return target;
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "verify:release:registry": "npm run verify:release:runtime && npm run verify:release:lock && npm run verify:release:installed",
     "generate:open-tool-descriptors": "node scripts/materialize-open-tool-descriptors.mjs --write",
     "verify:open-tool-descriptors": "node scripts/materialize-open-tool-descriptors.mjs --check",
+    "prepare:open-accepted-production": "node scripts/prepare-open-accepted-production.mjs",
     "build:runtime-workspaces": "npm run build -w @dexterai/x402-core",
     "typecheck:open-release": "tsc --noEmit --strict --skipLibCheck --target ES2022 --module ESNext --moduleResolution Bundler --jsx react-jsx --allowImportingTsExtensions apps-sdk/ui/src/sdk/mcp-apps-bridge.ts apps-sdk/ui/src/sdk/call-tool-result.ts",
     "build:apps-sdk:local": "vite build --config apps-sdk/vite.config.ts",

--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -16,15 +16,15 @@
     },
     "integratedApiRelease": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "6d8de2cee71fc217559fa2a2825fa2a25faf9497",
-      "tree": "a8f7a84e001bcd06f0418eb149da4e14fbafbfeb",
+      "commit": "8bf63be793f08c800f057d1fe2075d10875ea405",
+      "tree": "f89cabbc002494ceb5ec629697c5a77caf66d358",
       "governedContractCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
       "governedContractTree": "b8a3bdd790379f82b959663e679960f213addb5b"
     },
     "portfolioProjection": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "6d8de2cee71fc217559fa2a2825fa2a25faf9497",
-      "tree": "a8f7a84e001bcd06f0418eb149da4e14fbafbfeb",
+      "commit": "8bf63be793f08c800f057d1fe2075d10875ea405",
+      "tree": "f89cabbc002494ceb5ec629697c5a77caf66d358",
       "sourcePaths": [
         "src/portfolio/approvedActionTargets.ts",
         "src/routes/passkeyMcpBinding.ts",
@@ -39,8 +39,8 @@
     },
     "facilitator": {
       "repository": "https://github.com/Dexter-DAO/dexter-facilitator",
-      "commit": "df370826b7b951dfc825a689c4e6f3b1928ee5e2",
-      "tree": "a9b4b18eb350143f3265834571c910891c83dd5c",
+      "commit": "801547315a59a48fc8dcb4d3e42e40c2ee5ac09e",
+      "tree": "5f54c0c08eb004e4e8d810abccdaefaa2d7f7898",
       "bindingFixture": {
         "consumerPath": "tests/fixtures/governed-agent-trade-api-facilitator-binding-v1.json",
         "apiPath": "tests/fixtures/governed-agent-trade-api-facilitator-binding-v1.json",

--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -16,15 +16,15 @@
     },
     "integratedApiRelease": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "8bf63be793f08c800f057d1fe2075d10875ea405",
-      "tree": "f89cabbc002494ceb5ec629697c5a77caf66d358",
+      "commit": "5775594114076d4ea76fcaa9d8f9ca8876919d80",
+      "tree": "558288b2c7ee336042ed5fcb953fe7fb533a6c1f",
       "governedContractCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
       "governedContractTree": "b8a3bdd790379f82b959663e679960f213addb5b"
     },
     "portfolioProjection": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "8bf63be793f08c800f057d1fe2075d10875ea405",
-      "tree": "f89cabbc002494ceb5ec629697c5a77caf66d358",
+      "commit": "5775594114076d4ea76fcaa9d8f9ca8876919d80",
+      "tree": "558288b2c7ee336042ed5fcb953fe7fb533a6c1f",
       "sourcePaths": [
         "src/portfolio/approvedActionTargets.ts",
         "src/routes/passkeyMcpBinding.ts",

--- a/release/opendexter-accepted-production.json
+++ b/release/opendexter-accepted-production.json
@@ -4,12 +4,12 @@
   "api": {
     "endpoint": "https://api.dexter.cash/health",
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "releaseId": "8bf63be793f0-3731abcfb7040db6-43480b2754e7",
-    "sourceCommit": "8bf63be793f08c800f057d1fe2075d10875ea405",
-    "sourceTree": "f89cabbc002494ceb5ec629697c5a77caf66d358",
-    "toolingCommit": "8bf63be793f08c800f057d1fe2075d10875ea405",
-    "artifactSha256": "3731abcfb7040db600f54d4ac498efab1f8bd2133b44e4f34d4c59c74d707852",
-    "metadataBindingSha256": "192c6f9bc0fd1dfae96626157fbf24d5b2cd294afb80bd79bcc7d51ecf1508d7"
+    "releaseId": "577559411407-64c88c1e464c7884-0c92d24405a6",
+    "sourceCommit": "5775594114076d4ea76fcaa9d8f9ca8876919d80",
+    "sourceTree": "558288b2c7ee336042ed5fcb953fe7fb533a6c1f",
+    "toolingCommit": "5775594114076d4ea76fcaa9d8f9ca8876919d80",
+    "artifactSha256": "64c88c1e464c7884e6e73fc0eab701974a5d961c48fecc75984af919b8a9202d",
+    "metadataBindingSha256": "030ab6344540d152bbd6d0c9cfca2c1b4501c6d002facfb343003661aae4bbbf"
   },
   "facilitator": {
     "endpoint": "https://x402.dexter.cash/version",

--- a/release/opendexter-accepted-production.json
+++ b/release/opendexter-accepted-production.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "kind": "opendexter-accepted-production-receipt/v1",
+  "api": {
+    "endpoint": "https://api.dexter.cash/health",
+    "repository": "https://github.com/Dexter-DAO/dexter-api",
+    "releaseId": "8bf63be793f0-3731abcfb7040db6-43480b2754e7",
+    "sourceCommit": "8bf63be793f08c800f057d1fe2075d10875ea405",
+    "sourceTree": "f89cabbc002494ceb5ec629697c5a77caf66d358",
+    "toolingCommit": "8bf63be793f08c800f057d1fe2075d10875ea405",
+    "artifactSha256": "3731abcfb7040db600f54d4ac498efab1f8bd2133b44e4f34d4c59c74d707852",
+    "metadataBindingSha256": "192c6f9bc0fd1dfae96626157fbf24d5b2cd294afb80bd79bcc7d51ecf1508d7"
+  },
+  "facilitator": {
+    "endpoint": "https://x402.dexter.cash/version",
+    "repository": "https://github.com/Dexter-DAO/dexter-facilitator",
+    "namespace": "dexter-facilitator-immutable-release/v1",
+    "sourceCommit": "801547315a59a48fc8dcb4d3e42e40c2ee5ac09e",
+    "sourceTree": "5f54c0c08eb004e4e8d810abccdaefaa2d7f7898",
+    "sourceArchiveSha256": "e0f3d80bbb2a25b3a138d2d16b36bc02fefb16b9c6687a5e6402619f12255808",
+    "artifactSha256": "6144541c24b5f1dd14388b6a223b5f98f0d6311b7a573bd1a0a4ab6ebbe52952",
+    "artifactBindingDigest": "eb3759885bb5a94ab97e52525d05b16349a4a72dc1352624b53ab403e3255e5c",
+    "metadataBindingDigest": "52a4c7e5c46fa7d660cb502cdcaa81f37f04581305e39e5214d556fa0c9186cb"
+  }
+}

--- a/release/opendexter-source-contracts.json
+++ b/release/opendexter-source-contracts.json
@@ -13,15 +13,15 @@
   },
   "integratedApiRelease": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "6d8de2cee71fc217559fa2a2825fa2a25faf9497",
-    "tree": "a8f7a84e001bcd06f0418eb149da4e14fbafbfeb",
+    "commit": "8bf63be793f08c800f057d1fe2075d10875ea405",
+    "tree": "f89cabbc002494ceb5ec629697c5a77caf66d358",
     "governedContractCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
     "governedContractTree": "b8a3bdd790379f82b959663e679960f213addb5b"
   },
   "portfolioProjection": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "6d8de2cee71fc217559fa2a2825fa2a25faf9497",
-    "tree": "a8f7a84e001bcd06f0418eb149da4e14fbafbfeb",
+    "commit": "8bf63be793f08c800f057d1fe2075d10875ea405",
+    "tree": "f89cabbc002494ceb5ec629697c5a77caf66d358",
     "sourcePaths": [
       "src/portfolio/approvedActionTargets.ts",
       "src/routes/passkeyMcpBinding.ts",
@@ -36,8 +36,8 @@
   },
   "facilitator": {
     "repository": "https://github.com/Dexter-DAO/dexter-facilitator",
-    "commit": "df370826b7b951dfc825a689c4e6f3b1928ee5e2",
-    "tree": "a9b4b18eb350143f3265834571c910891c83dd5c",
+    "commit": "801547315a59a48fc8dcb4d3e42e40c2ee5ac09e",
+    "tree": "5f54c0c08eb004e4e8d810abccdaefaa2d7f7898",
     "bindingFixture": {
       "consumerPath": "tests/fixtures/governed-agent-trade-api-facilitator-binding-v1.json",
       "apiPath": "tests/fixtures/governed-agent-trade-api-facilitator-binding-v1.json",

--- a/release/opendexter-source-contracts.json
+++ b/release/opendexter-source-contracts.json
@@ -13,15 +13,15 @@
   },
   "integratedApiRelease": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "8bf63be793f08c800f057d1fe2075d10875ea405",
-    "tree": "f89cabbc002494ceb5ec629697c5a77caf66d358",
+    "commit": "5775594114076d4ea76fcaa9d8f9ca8876919d80",
+    "tree": "558288b2c7ee336042ed5fcb953fe7fb533a6c1f",
     "governedContractCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
     "governedContractTree": "b8a3bdd790379f82b959663e679960f213addb5b"
   },
   "portfolioProjection": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "8bf63be793f08c800f057d1fe2075d10875ea405",
-    "tree": "f89cabbc002494ceb5ec629697c5a77caf66d358",
+    "commit": "5775594114076d4ea76fcaa9d8f9ca8876919d80",
+    "tree": "558288b2c7ee336042ed5fcb953fe7fb533a6c1f",
     "sourcePaths": [
       "src/portfolio/approvedActionTargets.ts",
       "src/routes/passkeyMcpBinding.ts",

--- a/scripts/materialize-open-tool-descriptors.mjs
+++ b/scripts/materialize-open-tool-descriptors.mjs
@@ -34,6 +34,11 @@ import {
   runOpenReleaseFinalization,
 } from '../lib/open-release-finalization.mjs';
 import { canonicalHash } from '../lib/governed-canonical-identity.mjs';
+import {
+  OPENDEXTER_API_REPOSITORY,
+  OPENDEXTER_FACILITATOR_REPOSITORY,
+  verifyOpenDexterAcceptedProductionReceipt,
+} from '../lib/open-accepted-production-receipt.mjs';
 
 const execFileAsync = promisify(execFile);
 const CANONICAL_SOURCE_ORIGIN =
@@ -48,13 +53,16 @@ export const OPENDEXTER_SOURCE_CONTRACTS_PATH = resolve(
   repositoryRoot,
   'release/opendexter-source-contracts.json',
 );
+export const OPENDEXTER_ACCEPTED_PRODUCTION_PATH = resolve(
+  repositoryRoot,
+  'release/opendexter-accepted-production.json',
+);
 
 const SOURCE_CONTRACTS_KIND = 'opendexter-source-contracts/v3';
 const DESCRIPTOR_KIND = 'opendexter-hosted-tool-descriptors/v2';
-const API_REPOSITORY = 'https://github.com/Dexter-DAO/dexter-api';
+const API_REPOSITORY = OPENDEXTER_API_REPOSITORY;
 const API_GIT_ORIGIN = `${API_REPOSITORY}.git`;
-const FACILITATOR_REPOSITORY =
-  'https://github.com/Dexter-DAO/dexter-facilitator';
+const FACILITATOR_REPOSITORY = OPENDEXTER_FACILITATOR_REPOSITORY;
 const FACILITATOR_GIT_ORIGIN = `${FACILITATOR_REPOSITORY}.git`;
 const MCP_REPOSITORY = 'https://github.com/Dexter-DAO/dexter-mcp';
 const PRIVATE_SOURCE_RECEIPT_KIND =
@@ -103,14 +111,10 @@ const EXPECTED_SOURCE_CONTRACTS = Object.freeze({
     '449fc6b5a253d6856ae9f0990932dc6cefb84871c981229afb603a6314efa798',
   apiCanonicalBodyDigest:
     '48e77a936f06fe07b66fee7c2cb9126e8305d4e180c2c304513d5f0ea1636e16',
-  integratedApiCommit: '6d8de2cee71fc217559fa2a2825fa2a25faf9497',
-  integratedApiTree: 'a8f7a84e001bcd06f0418eb149da4e14fbafbfeb',
   portfolioProjectionFixtureSha256:
     '9c4c29b0d911b490d53a375eca1ae302501397be9c56250591bafaeb34a4e625',
   portfolioProjectionCanonicalDigest:
     'f4a3f826aa1c08531d42da402f08df709642ea75a84fd74608be75cdba2fc28a',
-  facilitatorCommit: 'df370826b7b951dfc825a689c4e6f3b1928ee5e2',
-  facilitatorTree: 'a9b4b18eb350143f3265834571c910891c83dd5c',
   bindingFixtureSha256:
     '66bbd343637fe9b3af245b2ace823a9dff1d8032e2dd01da7ee4bd71cc1ff7d6',
   mcpCommit: '0647bbdf081733ac3ca5ba82850c2c1db79307cb',
@@ -139,7 +143,20 @@ function exactKeys(value, expected) {
       === JSON.stringify([...expected].sort());
 }
 
-export function hasExactOpenDexterSourceContractsShape(sourceContracts) {
+export function hasExactOpenDexterSourceContractsShape(
+  sourceContracts,
+  acceptedProduction = JSON.parse(readFileSync(
+    OPENDEXTER_ACCEPTED_PRODUCTION_PATH,
+    'utf8',
+  )),
+) {
+  try {
+    verifyOpenDexterAcceptedProductionReceipt(acceptedProduction);
+  } catch {
+    return false;
+  }
+  const acceptedApi = acceptedProduction.api;
+  const acceptedFacilitator = acceptedProduction.facilitator;
   const api = sourceContracts?.api;
   const integratedApiRelease = sourceContracts?.integratedApiRelease;
   const portfolioProjection = sourceContracts?.portfolioProjection;
@@ -193,9 +210,9 @@ export function hasExactOpenDexterSourceContractsShape(sourceContracts) {
       === EXPECTED_SOURCE_CONTRACTS.apiCanonicalBodyDigest
     && integratedApiRelease.repository === API_REPOSITORY
     && integratedApiRelease.commit
-      === EXPECTED_SOURCE_CONTRACTS.integratedApiCommit
+      === acceptedApi.sourceCommit
     && integratedApiRelease.tree
-      === EXPECTED_SOURCE_CONTRACTS.integratedApiTree
+      === acceptedApi.sourceTree
     && integratedApiRelease.governedContractCommit === api.commit
     && integratedApiRelease.governedContractTree === api.tree
     && portfolioProjection.repository === API_REPOSITORY
@@ -211,8 +228,8 @@ export function hasExactOpenDexterSourceContractsShape(sourceContracts) {
     && projectionFixture.canonicalDigest
       === EXPECTED_SOURCE_CONTRACTS.portfolioProjectionCanonicalDigest
     && facilitator.repository === FACILITATOR_REPOSITORY
-    && facilitator.commit === EXPECTED_SOURCE_CONTRACTS.facilitatorCommit
-    && facilitator.tree === EXPECTED_SOURCE_CONTRACTS.facilitatorTree
+    && facilitator.commit === acceptedFacilitator.sourceCommit
+    && facilitator.tree === acceptedFacilitator.sourceTree
     && bindingFixture.consumerPath === BINDING_FIXTURE_CONSUMER_PATH
     && bindingFixture.apiPath === BINDING_FIXTURE_API_PATH
     && bindingFixture.facilitatorPath === BINDING_FIXTURE_FACILITATOR_PATH
@@ -232,8 +249,14 @@ export function hasExactOpenDexterSourceContractsShape(sourceContracts) {
     && /^[0-9a-f]{40}$/.test(facilitator.tree);
 }
 
-export function verifyExactOpenDexterSourceContractsShape(sourceContracts) {
-  if (!hasExactOpenDexterSourceContractsShape(sourceContracts)) {
+export function verifyExactOpenDexterSourceContractsShape(
+  sourceContracts,
+  acceptedProduction,
+) {
+  if (!hasExactOpenDexterSourceContractsShape(
+    sourceContracts,
+    acceptedProduction,
+  )) {
     throw new Error('OpenDexter source-contract manifest is invalid');
   }
   return sourceContracts;
@@ -246,8 +269,18 @@ export async function readOpenDexterSourceContracts({
     sourceRoot,
     'release/opendexter-source-contracts.json',
   );
-  const sourceContracts = await readJson(sourceContractsPath);
-  verifyExactOpenDexterSourceContractsShape(sourceContracts);
+  const acceptedProductionPath = resolve(
+    sourceRoot,
+    'release/opendexter-accepted-production.json',
+  );
+  const [sourceContracts, acceptedProduction] = await Promise.all([
+    readJson(sourceContractsPath),
+    readJson(acceptedProductionPath),
+  ]);
+  verifyExactOpenDexterSourceContractsShape(
+    sourceContracts,
+    acceptedProduction,
+  );
 
   const fixturePath = resolve(sourceRoot, RECONCILE_FIXTURE_PATH);
   const fixtureBytes = await readFile(fixturePath);
@@ -317,6 +350,33 @@ export async function readOpenDexterSourceContracts({
     ),
   ]);
   return sourceContracts;
+}
+
+/**
+ * Preserve the reviewed, slow-moving contract policy while deriving every
+ * mutable API/facilitator source identity from one accepted-production
+ * receipt. The output remains sourceContracts/v3 for existing public
+ * consumers; it is generated evidence, not a hand-maintained pin table.
+ */
+export function deriveOpenDexterSourceContractsForAcceptedProduction({
+  sourceContracts,
+  acceptedProduction,
+} = {}) {
+  verifyOpenDexterAcceptedProductionReceipt(acceptedProduction);
+  if (!sourceContracts || typeof sourceContracts !== 'object') {
+    throw new Error('OpenDexter source-contract policy is invalid');
+  }
+  const derived = structuredClone(sourceContracts);
+  derived.integratedApiRelease.commit = acceptedProduction.api.sourceCommit;
+  derived.integratedApiRelease.tree = acceptedProduction.api.sourceTree;
+  derived.portfolioProjection.commit = acceptedProduction.api.sourceCommit;
+  derived.portfolioProjection.tree = acceptedProduction.api.sourceTree;
+  derived.facilitator.commit = acceptedProduction.facilitator.sourceCommit;
+  derived.facilitator.tree = acceptedProduction.facilitator.sourceTree;
+  return verifyExactOpenDexterSourceContractsShape(
+    derived,
+    acceptedProduction,
+  );
 }
 
 function commandText(result) {
@@ -1560,7 +1620,10 @@ export async function materializeOpenToolDescriptors(options = {}) {
  * This starts no listener or reaper and is suitable for ordinary schema tests;
  * release write/check still go through the strict committed-archive function.
  */
-export async function materializeOpenToolDescriptorsFromRegistrations() {
+export async function materializeOpenToolDescriptorsFromRegistrations({
+  sourceContracts: suppliedSourceContracts,
+  acceptedProduction: suppliedAcceptedProduction,
+} = {}) {
   const [
     { buildHostedOpenToolDescriptor },
     { createOpenMcpServer },
@@ -1573,13 +1636,19 @@ export async function materializeOpenToolDescriptorsFromRegistrations() {
       OPEN_MCP_PROTECTED_RESOURCE_PATHS,
       OPEN_MCP_TOKEN_ISSUER,
     },
-    sourceContracts,
+    loadedSourceContracts,
   ] = await Promise.all([
     import('../lib/open-tool-contracts.mjs'),
     import('../open-mcp-server.mjs'),
     import('../lib/open-tool-auth.mjs'),
-    readOpenDexterSourceContracts(),
+    suppliedSourceContracts
+      ? Promise.resolve(suppliedSourceContracts)
+      : readOpenDexterSourceContracts(),
   ]);
+  const sourceContracts = verifyExactOpenDexterSourceContractsShape(
+    loadedSourceContracts,
+    suppliedAcceptedProduction,
+  );
   const server = createOpenMcpServer({ includeResources: false });
   const {
     schemaVersion: _schemaVersion,

--- a/scripts/prepare-open-accepted-production.mjs
+++ b/scripts/prepare-open-accepted-production.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  resolveOpenDexterAcceptedProduction,
+  serializeOpenDexterAcceptedProductionReceipt,
+  writeFileAtomically,
+} from '../lib/open-accepted-production-receipt.mjs';
+import {
+  deriveOpenDexterSourceContractsForAcceptedProduction,
+  materializeOpenToolDescriptorsFromRegistrations,
+  OPENDEXTER_ACCEPTED_PRODUCTION_PATH,
+  OPENDEXTER_SOURCE_CONTRACTS_PATH,
+  OPEN_TOOL_DESCRIPTOR_PATH,
+  serializeOpenToolDescriptors,
+} from './materialize-open-tool-descriptors.mjs';
+
+export async function prepareOpenDexterAcceptedProduction({
+  fetchImpl = globalThis.fetch,
+  acceptedProductionPath = OPENDEXTER_ACCEPTED_PRODUCTION_PATH,
+  sourceContractsPath = OPENDEXTER_SOURCE_CONTRACTS_PATH,
+  descriptorPath = OPEN_TOOL_DESCRIPTOR_PATH,
+} = {}) {
+  const currentSourceContracts = JSON.parse(
+    await readFile(sourceContractsPath, 'utf8'),
+  );
+  const acceptedProduction = await resolveOpenDexterAcceptedProduction({
+    fetchImpl,
+  });
+  const sourceContracts =
+    deriveOpenDexterSourceContractsForAcceptedProduction({
+      sourceContracts: currentSourceContracts,
+      acceptedProduction,
+    });
+  const descriptor = await materializeOpenToolDescriptorsFromRegistrations({
+    sourceContracts,
+    acceptedProduction,
+  });
+
+  const outputs = [
+    [
+      acceptedProductionPath,
+      serializeOpenDexterAcceptedProductionReceipt(acceptedProduction),
+    ],
+    [sourceContractsPath, `${JSON.stringify(sourceContracts, null, 2)}\n`],
+    [descriptorPath, serializeOpenToolDescriptors(descriptor)],
+  ];
+  for (const [path, bytes] of outputs) {
+    await writeFileAtomically(path, bytes);
+  }
+  return Object.freeze({
+    acceptedProduction,
+    paths: Object.freeze(outputs.map(([path]) => path)),
+  });
+}
+
+const isMainModule = process.argv[1]
+  ? resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+
+if (isMainModule) {
+  try {
+    if (process.argv.length !== 2) {
+      throw new Error('usage: node scripts/prepare-open-accepted-production.mjs');
+    }
+    const result = await prepareOpenDexterAcceptedProduction({
+      acceptedProductionPath: OPENDEXTER_ACCEPTED_PRODUCTION_PATH,
+      sourceContractsPath: OPENDEXTER_SOURCE_CONTRACTS_PATH,
+      descriptorPath: OPEN_TOOL_DESCRIPTOR_PATH,
+    });
+    process.stdout.write(
+      `Prepared OpenDexter from accepted API ${result.acceptedProduction.api.sourceCommit} `
+      + `and facilitator ${result.acceptedProduction.facilitator.sourceCommit}\n`,
+    );
+  } catch (error) {
+    process.stderr.write(`${error?.message ?? String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tests/open-accepted-production-receipt.test.mjs
+++ b/tests/open-accepted-production-receipt.test.mjs
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  createOpenDexterAcceptedProductionReceipt,
+  OPENDEXTER_API_HEALTH_ENDPOINT,
+  OPENDEXTER_FACILITATOR_VERSION_ENDPOINT,
+  resolveOpenDexterAcceptedProduction,
+  serializeOpenDexterAcceptedProductionReceipt,
+  verifyOpenDexterAcceptedProductionReceipt,
+} from '../lib/open-accepted-production-receipt.mjs';
+import {
+  deriveOpenDexterSourceContractsForAcceptedProduction,
+  readOpenDexterSourceContracts,
+} from '../scripts/materialize-open-tool-descriptors.mjs';
+import {
+  prepareOpenDexterAcceptedProduction,
+} from '../scripts/prepare-open-accepted-production.mjs';
+
+const RECEIPT_PATH = new URL(
+  '../release/opendexter-accepted-production.json',
+  import.meta.url,
+);
+const SOURCE_CONTRACTS_PATH = new URL(
+  '../release/opendexter-source-contracts.json',
+  import.meta.url,
+);
+
+function receipt() {
+  return JSON.parse(readFileSync(RECEIPT_PATH, 'utf8'));
+}
+
+function advertisements(value = receipt()) {
+  return {
+    api: {
+      ok: true,
+      service: 'dexter-api',
+      release: {
+        mode: 'immutable-release',
+        releaseId: value.api.releaseId,
+        sourceCommit: value.api.sourceCommit,
+        sourceTree: value.api.sourceTree,
+        toolingCommit: value.api.toolingCommit,
+        artifactSha256: value.api.artifactSha256,
+        metadataBindingSha256: value.api.metadataBindingSha256,
+      },
+    },
+    facilitator: {
+      commit: value.facilitator.sourceCommit,
+      identitySource: 'release-provenance',
+      startedAt: 'deliberately-not-receipt-evidence',
+      release: {
+        namespace: value.facilitator.namespace,
+        sourceCommit: value.facilitator.sourceCommit,
+        sourceTree: value.facilitator.sourceTree,
+        sourceArchiveSha256: value.facilitator.sourceArchiveSha256,
+        artifactSha256: value.facilitator.artifactSha256,
+        artifactBindingDigest: value.facilitator.artifactBindingDigest,
+        metadataBindingDigest: value.facilitator.metadataBindingDigest,
+      },
+    },
+  };
+}
+
+function jsonResponse(endpoint, value, overrides = {}) {
+  const bytes = Buffer.from(JSON.stringify(value));
+  return {
+    ok: true,
+    status: 200,
+    url: endpoint,
+    arrayBuffer: async () => bytes,
+    ...overrides,
+  };
+}
+
+function exactFetch(advertisement, calls) {
+  return async (endpoint, options) => {
+    calls.push({ endpoint, options });
+    if (endpoint === OPENDEXTER_API_HEALTH_ENDPOINT) {
+      return jsonResponse(endpoint, advertisement.api);
+    }
+    if (endpoint === OPENDEXTER_FACILITATOR_VERSION_ENDPOINT) {
+      return jsonResponse(endpoint, advertisement.facilitator);
+    }
+    throw new Error(`unexpected endpoint ${endpoint}`);
+  };
+}
+
+test('accepted-production receipt is exact, deterministic, and owns live pins', async () => {
+  const accepted = receipt();
+  assert.equal(
+    verifyOpenDexterAcceptedProductionReceipt(accepted),
+    accepted,
+  );
+  const projected = createOpenDexterAcceptedProductionReceipt({
+    apiAdvertisement: advertisements(accepted).api,
+    facilitatorAdvertisement: advertisements(accepted).facilitator,
+  });
+  assert.deepEqual(projected, accepted);
+  assert.equal(
+    serializeOpenDexterAcceptedProductionReceipt(projected),
+    readFileSync(RECEIPT_PATH, 'utf8'),
+  );
+
+  const sourceContracts = JSON.parse(readFileSync(
+    SOURCE_CONTRACTS_PATH,
+    'utf8',
+  ));
+  assert.equal(
+    sourceContracts.integratedApiRelease.commit,
+    accepted.api.sourceCommit,
+  );
+  assert.equal(
+    sourceContracts.portfolioProjection.tree,
+    accepted.api.sourceTree,
+  );
+  assert.equal(
+    sourceContracts.facilitator.commit,
+    accepted.facilitator.sourceCommit,
+  );
+  const originalFetch = globalThis.fetch;
+  let contactedProduction = false;
+  globalThis.fetch = async () => {
+    contactedProduction = true;
+    throw new Error('frozen verification must not fetch');
+  };
+  try {
+    assert.deepEqual(await readOpenDexterSourceContracts(), sourceContracts);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(contactedProduction, false);
+});
+
+test('production resolver reads each fixed endpoint exactly once', async () => {
+  const calls = [];
+  const accepted = await resolveOpenDexterAcceptedProduction({
+    fetchImpl: exactFetch(advertisements(), calls),
+  });
+  assert.deepEqual(accepted, receipt());
+  assert.deepEqual(calls.map(({ endpoint }) => endpoint).sort(), [
+    OPENDEXTER_API_HEALTH_ENDPOINT,
+    OPENDEXTER_FACILITATOR_VERSION_ENDPOINT,
+  ].sort());
+  for (const { options } of calls) {
+    assert.equal(options.redirect, 'error');
+    assert.equal(options.headers.accept, 'application/json');
+  }
+});
+
+test('receipt validation refuses substitution and inconsistent advertisements', async () => {
+  const accepted = receipt();
+  const hostileReceipt = structuredClone(accepted);
+  hostileReceipt.api.sourceCommit = 'f'.repeat(40);
+  assert.throws(
+    () => verifyOpenDexterAcceptedProductionReceipt(hostileReceipt),
+    /receipt is invalid/,
+  );
+
+  const hostileAdvertisement = advertisements(accepted);
+  hostileAdvertisement.facilitator.commit = 'f'.repeat(40);
+  assert.throws(
+    () => createOpenDexterAcceptedProductionReceipt({
+      apiAdvertisement: hostileAdvertisement.api,
+      facilitatorAdvertisement: hostileAdvertisement.facilitator,
+    }),
+    /commit is inconsistent/,
+  );
+
+  const calls = [];
+  await assert.rejects(
+    resolveOpenDexterAcceptedProduction({
+      fetchImpl: async (endpoint, options) => {
+        calls.push({ endpoint, options });
+        const value = endpoint === OPENDEXTER_API_HEALTH_ENDPOINT
+          ? advertisements().api
+          : advertisements().facilitator;
+        return jsonResponse(endpoint, value, {
+          url: `${endpoint}/redirected`,
+        });
+      },
+    }),
+    /advertisement is invalid/,
+  );
+  assert.equal(calls.length, 2);
+});
+
+test('one preparation writes the receipt and both generated derivatives', async (t) => {
+  const workspace = mkdtempSync(join(tmpdir(), 'opendexter-preparation-'));
+  const releaseRoot = join(workspace, 'release');
+  mkdirSync(releaseRoot);
+  t.after(() => rmSync(workspace, { recursive: true, force: true }));
+  const acceptedPath = join(releaseRoot, 'accepted.json');
+  const sourcePath = join(releaseRoot, 'source-contracts.json');
+  const descriptorPath = join(releaseRoot, 'descriptor.json');
+  writeFileSync(sourcePath, readFileSync(SOURCE_CONTRACTS_PATH));
+
+  const calls = [];
+  const result = await prepareOpenDexterAcceptedProduction({
+    fetchImpl: exactFetch(advertisements(), calls),
+    acceptedProductionPath: acceptedPath,
+    sourceContractsPath: sourcePath,
+    descriptorPath,
+  });
+  assert.equal(calls.length, 2);
+  assert.deepEqual(JSON.parse(readFileSync(acceptedPath)), receipt());
+  const generatedContracts = JSON.parse(readFileSync(sourcePath));
+  assert.deepEqual(
+    generatedContracts,
+    deriveOpenDexterSourceContractsForAcceptedProduction({
+      sourceContracts: JSON.parse(readFileSync(SOURCE_CONTRACTS_PATH)),
+      acceptedProduction: receipt(),
+    }),
+  );
+  const descriptor = JSON.parse(readFileSync(descriptorPath));
+  assert.deepEqual(descriptor.sourceContracts, generatedContracts);
+  assert.deepEqual(result.paths, [acceptedPath, sourcePath, descriptorPath]);
+  for (const path of result.paths) {
+    assert.equal(statSync(path).mode & 0o777, 0o644);
+  }
+});

--- a/tests/open-tool-descriptors.test.mjs
+++ b/tests/open-tool-descriptors.test.mjs
@@ -394,6 +394,10 @@ test('source materializer emits one deterministic full hosted descriptor', async
   )));
   assert.equal(descriptor.sourceContracts.schemaVersion, 3);
   assert.equal(descriptor.sourceContracts.kind, 'opendexter-source-contracts/v3');
+  const acceptedProduction = JSON.parse(readFileSync(
+    new URL('../release/opendexter-accepted-production.json', import.meta.url),
+    'utf8',
+  ));
   assert.equal(
     descriptor.sourceContracts.api.commit,
     'c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b',
@@ -404,15 +408,15 @@ test('source materializer emits one deterministic full hosted descriptor', async
   );
   assert.deepEqual(descriptor.sourceContracts.integratedApiRelease, {
     repository: 'https://github.com/Dexter-DAO/dexter-api',
-    commit: '6d8de2cee71fc217559fa2a2825fa2a25faf9497',
-    tree: 'a8f7a84e001bcd06f0418eb149da4e14fbafbfeb',
+    commit: acceptedProduction.api.sourceCommit,
+    tree: acceptedProduction.api.sourceTree,
     governedContractCommit: 'c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b',
     governedContractTree: 'b8a3bdd790379f82b959663e679960f213addb5b',
   });
   assert.deepEqual(descriptor.sourceContracts.portfolioProjection, {
     repository: 'https://github.com/Dexter-DAO/dexter-api',
-    commit: '6d8de2cee71fc217559fa2a2825fa2a25faf9497',
-    tree: 'a8f7a84e001bcd06f0418eb149da4e14fbafbfeb',
+    commit: acceptedProduction.api.sourceCommit,
+    tree: acceptedProduction.api.sourceTree,
     sourcePaths: [
       'src/portfolio/approvedActionTargets.ts',
       'src/routes/passkeyMcpBinding.ts',
@@ -431,11 +435,11 @@ test('source materializer emits one deterministic full hosted descriptor', async
   });
   assert.equal(
     descriptor.sourceContracts.facilitator.commit,
-    'df370826b7b951dfc825a689c4e6f3b1928ee5e2',
+    acceptedProduction.facilitator.sourceCommit,
   );
   assert.equal(
     descriptor.sourceContracts.facilitator.tree,
-    'a9b4b18eb350143f3265834571c910891c83dd5c',
+    acceptedProduction.facilitator.sourceTree,
   );
   assert.equal(
     descriptor.sourceContracts.facilitator.bindingFixture.sha256,


### PR DESCRIPTION
## Summary
- derive hosted source contracts from the accepted production receipt
- fail closed when integrated source identities drift
- refresh the receipt to the live API release 577559411407

## Verification
- npm run build:runtime-workspaces
- node --test tests/*.test.mjs (555 passed, 1 skipped)
- npm run typecheck:open-release
- strict verify:open-tool-descriptors against the exact API and facilitator source roots
- no-network descriptor materialization proof (12 tools, 12 connected)