### PR TITLE
fix: reconcile hosted check input schemas

### DIFF
--- a/lib/open-check-result.mjs
+++ b/lib/open-check-result.mjs
@@ -1,3 +1,5 @@
+import { reconcileHostedCheckInputSchema } from './open-check-schema.mjs';
+
 const SAFE_PAYMENT_OPTION_FIELDS = Object.freeze([
   'price',
   'priceFormatted',
@@ -94,9 +96,24 @@ export function buildHostedCheckModelResult({
       : typeof checkResult?.paymentRequired === 'boolean'
         ? checkResult.paymentRequired
         : null;
+  const publicFields = publicCheckFields(checkResult);
+  const schemaResolution = reconcileHostedCheckInputSchema({
+    liveSchema: publicFields.inputSchema,
+    enrichment,
+    resourceUrl: url,
+  });
+  if (schemaResolution.replaced) {
+    publicFields.inputSchema = schemaResolution.schema;
+  }
+  if (Object.prototype.hasOwnProperty.call(publicFields, 'inputSchema')) {
+    publicFields.inputSchemaSource = schemaResolution.source;
+    if (schemaResolution.rejectedSources.length > 0) {
+      publicFields.inputSchemaRejectedSources = schemaResolution.rejectedSources;
+    }
+  }
 
   return {
-    ...publicCheckFields(checkResult),
+    ...publicFields,
     ...(requiresPayment === null ? {} : { requiresPayment }),
     intentId,
     quoteOnly: intentId === null,

--- a/lib/open-check-schema.mjs
+++ b/lib/open-check-schema.mjs
@@ -13,7 +13,11 @@ function persistedSchemaCandidate(enrichment) {
   const schemaSource = typeof resource.input_schema_source === 'string'
     ? resource.input_schema_source.trim()
     : '';
-  if (!schemaSource || schemaSource.toLowerCase() === 'none') return null;
+  // Only a normalized OpenAPI/catalog contract may repair the exact calling
+  // schema. A service profile is LLM-derived behavioral context, not an
+  // authoritative request shape, and a cached Bazaar copy must not overrule
+  // the seller's fresher live Bazaar declaration.
+  if (schemaSource.toLowerCase() !== 'openapi') return null;
   const rejectedSources = Array.isArray(resource.input_schema_rejected_sources)
     ? resource.input_schema_rejected_sources.filter(
         (source) => typeof source === 'string' && source.length > 0,

--- a/lib/open-check-schema.mjs
+++ b/lib/open-check-schema.mjs
@@ -1,0 +1,148 @@
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasOwn(object, key) {
+  return isPlainObject(object) && Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function persistedSchemaCandidate(enrichment) {
+  const resource = isPlainObject(enrichment?.resource) ? enrichment.resource : null;
+  if (!resource || !hasOwn(resource, 'input_schema')) return null;
+
+  const schemaSource = typeof resource.input_schema_source === 'string'
+    ? resource.input_schema_source.trim()
+    : '';
+  if (!schemaSource || schemaSource.toLowerCase() === 'none') return null;
+  const rejectedSources = Array.isArray(resource.input_schema_rejected_sources)
+    ? resource.input_schema_rejected_sources.filter(
+        (source) => typeof source === 'string' && source.length > 0,
+      )
+    : [];
+
+  return {
+    schema: resource.input_schema,
+    schemaSource,
+    rejectedSources,
+  };
+}
+
+function schemaHasConcreteInputs(schema) {
+  if (!isPlainObject(schema)) return false;
+
+  if (Array.isArray(schema.input_semantics) && schema.input_semantics.length > 0) {
+    return true;
+  }
+  if (typeof schema.$ref === 'string' && schema.$ref.trim() !== '') return true;
+  if (isPlainObject(schema.properties)) {
+    if (Object.keys(schema.properties).length > 0) return true;
+    if (schema.additionalProperties === true) return true;
+    return isPlainObject(schema.additionalProperties);
+  }
+  if (schema.additionalProperties === true || isPlainObject(schema.additionalProperties)) {
+    return true;
+  }
+  for (const keyword of ['oneOf', 'anyOf', 'allOf']) {
+    if (
+      Array.isArray(schema[keyword])
+      && schema[keyword].some(schemaHasConcreteInputs)
+    ) {
+      return true;
+    }
+  }
+  if (schema.type === 'array') return schemaHasConcreteInputs(schema.items);
+  return typeof schema.type === 'string' && schema.type !== 'object';
+}
+
+function isClosedEmptyObjectSchema(schema) {
+  return (
+    isPlainObject(schema)
+    && (schema.type === 'object' || isPlainObject(schema.properties))
+    && (!hasOwn(schema, 'properties')
+      || (isPlainObject(schema.properties) && Object.keys(schema.properties).length === 0))
+    && schema.additionalProperties === false
+  );
+}
+
+function fixedOperationSuffix(resourceUrl) {
+  if (typeof resourceUrl !== 'string' || resourceUrl.length === 0) return null;
+  let pathname;
+  try {
+    pathname = decodeURIComponent(new URL(resourceUrl).pathname);
+  } catch {
+    return null;
+  }
+  const lastSegment = pathname.split('/').filter(Boolean).at(-1) ?? '';
+  const match = lastSegment.match(/^.+:([A-Za-z_][\w-]*)$/);
+  return match?.[1] ?? null;
+}
+
+function isFixedOperationSoleField(schema, resourceUrl) {
+  if (!isPlainObject(schema) || !isPlainObject(schema.properties)) return false;
+  const operation = fixedOperationSuffix(resourceUrl);
+  if (!operation) return false;
+  const fields = Object.keys(schema.properties);
+  return fields.length === 1 && fields[0] === operation;
+}
+
+/**
+ * Select the input schema exposed by hosted x402_check without replacing live
+ * pricing, authentication, intent, or request evidence.
+ *
+ * A normalized catalog schema may repair a missing or closed-empty live schema.
+ * It may also repair the narrow fixed-operation parser failure where a literal
+ * RPC suffix (`model:execute`) appears as the sole request field, but only when
+ * a concrete persisted schema with explicit provenance corroborates the repair.
+ * Otherwise the live seller declaration remains authoritative and unchanged.
+ */
+export function reconcileHostedCheckInputSchema({
+  liveSchema,
+  enrichment,
+  resourceUrl,
+}) {
+  const persisted = persistedSchemaCandidate(enrichment);
+  if (!persisted || !schemaHasConcreteInputs(persisted.schema)) {
+    return {
+      schema: liveSchema,
+      source: 'live',
+      replaced: false,
+      rejectedSources: [],
+    };
+  }
+
+  const liveMissing = liveSchema === null || liveSchema === undefined;
+  const liveClosedEmpty = isClosedEmptyObjectSchema(liveSchema);
+  const fixedOperationPhantom = isFixedOperationSoleField(liveSchema, resourceUrl);
+  const persistedRepeatsPhantom = isFixedOperationSoleField(
+    persisted.schema,
+    resourceUrl,
+  );
+  const persistedRejectedLiveBazaar = persisted.rejectedSources.some(
+    (source) => source.toLowerCase() === 'bazaar',
+  );
+
+  if (
+    liveMissing
+    || liveClosedEmpty
+    || (
+      fixedOperationPhantom
+      && !persistedRepeatsPhantom
+      && persisted.schemaSource.toLowerCase() !== 'bazaar'
+      && persistedRejectedLiveBazaar
+    )
+  ) {
+    return {
+      schema: persisted.schema,
+      source: persisted.schemaSource,
+      replaced: true,
+      rejectedSources: persisted.rejectedSources,
+    };
+  }
+
+  return {
+    schema: liveSchema,
+    source: 'live',
+    replaced: false,
+    rejectedSources: [],
+  };
+}

--- a/lib/open-tool-contracts.mjs
+++ b/lib/open-tool-contracts.mjs
@@ -220,6 +220,8 @@ const OUTPUT_SCHEMAS = Object.freeze({
     enrichment_source: z.string().optional(),
     authMode: z.string().optional(),
     inputSchema: z.unknown().optional(),
+    inputSchemaSource: z.string().optional(),
+    inputSchemaRejectedSources: z.array(z.string()).optional(),
     outputSchema: z.unknown().optional(),
     error: z.unknown().optional(),
     message: z.string().optional(),

--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -398,6 +398,15 @@
             "type": "string"
           },
           "inputSchema": {},
+          "inputSchemaSource": {
+            "type": "string"
+          },
+          "inputSchemaRejectedSources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "outputSchema": {},
           "error": {},
           "message": {

--- a/tests/open-check-result-contract.test.mjs
+++ b/tests/open-check-result-contract.test.mjs
@@ -132,3 +132,83 @@ test('authenticated checks do not expose backend route names through errors', ()
   assert.equal(Object.hasOwn(structuredContent, 'message'), false);
   assert.doesNotMatch(JSON.stringify(structuredContent), /native|gateway|rail/i);
 });
+
+test('hosted check repairs only the schema while preserving live quote evidence', () => {
+  const persistedSchema = {
+    type: 'object',
+    properties: { contents: { type: 'array' } },
+    required: ['contents'],
+    additionalProperties: false,
+  };
+  const livePaymentOptions = [{
+    amountAtomic: '20000',
+    network: 'solana:mainnet',
+    payTo: 'seller-wallet',
+  }];
+  const enrichment = {
+    resource: {
+      input_schema: persistedSchema,
+      input_schema_source: 'openapi',
+      input_schema_rejected_sources: ['bazaar'],
+    },
+    history: [],
+  };
+
+  const structuredContent = buildHostedCheckModelResult({
+    checkResult: {
+      requiresPayment: true,
+      statusCode: 402,
+      authMode: 'paid',
+      paymentOptions: livePaymentOptions,
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    url: 'https://seller.example/v1/models/model:generateContent',
+    method: 'POST',
+    rawBodyProvided: false,
+    enrichment,
+    enrichmentSource: 'live_db',
+  });
+
+  assert.equal(structuredContent.inputSchema, persistedSchema);
+  assert.equal(structuredContent.inputSchemaSource, 'openapi');
+  assert.deepEqual(structuredContent.inputSchemaRejectedSources, ['bazaar']);
+  assert.deepEqual(structuredContent.paymentOptions, livePaymentOptions);
+  assert.equal(structuredContent.statusCode, 402);
+  assert.equal(structuredContent.authMode, 'paid');
+  assert.equal(structuredContent.enrichment, enrichment);
+  assert.equal(structuredContent.enrichment_source, 'live_db');
+});
+
+test('hosted check labels an unchanged informative seller schema as live', () => {
+  const liveSchema = {
+    type: 'object',
+    properties: { prompt: { type: 'string' } },
+    required: ['prompt'],
+    additionalProperties: false,
+  };
+
+  const structuredContent = buildHostedCheckModelResult({
+    checkResult: {
+      requiresPayment: true,
+      statusCode: 402,
+      paymentOptions: [{ amountAtomic: '1000', network: 'solana:mainnet' }],
+      inputSchema: liveSchema,
+    },
+    url: 'https://seller.example/v1/generate',
+    method: 'POST',
+    rawBodyProvided: false,
+    enrichment: null,
+    enrichmentSource: 'not_found',
+  });
+
+  assert.equal(structuredContent.inputSchema, liveSchema);
+  assert.equal(structuredContent.inputSchemaSource, 'live');
+  assert.equal(
+    Object.hasOwn(structuredContent, 'inputSchemaRejectedSources'),
+    false,
+  );
+});

--- a/tests/open-check-schema.test.mjs
+++ b/tests/open-check-schema.test.mjs
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { reconcileHostedCheckInputSchema } from '../lib/open-check-schema.mjs';
+
+const persistedOpenApi = {
+  type: 'object',
+  properties: {
+    contents: { type: 'array' },
+  },
+  required: ['contents'],
+  additionalProperties: false,
+};
+
+const persistedEnrichment = {
+  resource: {
+    input_schema: persistedOpenApi,
+    input_schema_source: 'openapi',
+    input_schema_rejected_sources: ['bazaar'],
+  },
+};
+
+test('informative live seller schema remains first', () => {
+  const liveSchema = {
+    type: 'object',
+    properties: { prompt: { type: 'string' } },
+    required: ['prompt'],
+    additionalProperties: false,
+  };
+
+  const resolved = reconcileHostedCheckInputSchema({
+    liveSchema,
+    enrichment: persistedEnrichment,
+    resourceUrl: 'https://seller.example/v1/generate',
+  });
+
+  assert.equal(resolved.schema, liveSchema);
+  assert.deepEqual(resolved, {
+    schema: liveSchema,
+    source: 'live',
+    replaced: false,
+    rejectedSources: [],
+  });
+});
+
+test('closed zero-field live schema falls back to richer persisted schema', () => {
+  for (const liveSchema of [
+    { type: 'object', properties: {}, additionalProperties: false },
+    { type: 'object', additionalProperties: false },
+  ]) {
+    assert.deepEqual(reconcileHostedCheckInputSchema({
+      liveSchema,
+      enrichment: persistedEnrichment,
+      resourceUrl: 'https://seller.example/v1/generate',
+    }), {
+      schema: persistedOpenApi,
+      source: 'openapi',
+      replaced: true,
+      rejectedSources: ['bazaar'],
+    });
+  }
+});
+
+test('fixed-operation sole-field phantom falls back only with richer corroboration', () => {
+  const livePhantom = {
+    type: 'object',
+    properties: { generateContent: { type: 'string' } },
+    required: ['generateContent'],
+    additionalProperties: false,
+  };
+  const resourceUrl = 'https://seller.example/v1/models/model:generateContent';
+
+  assert.deepEqual(reconcileHostedCheckInputSchema({
+    liveSchema: livePhantom,
+    enrichment: persistedEnrichment,
+    resourceUrl,
+  }), {
+    schema: persistedOpenApi,
+    source: 'openapi',
+    replaced: true,
+    rejectedSources: ['bazaar'],
+  });
+
+  assert.deepEqual(reconcileHostedCheckInputSchema({
+    liveSchema: livePhantom,
+    enrichment: {
+      resource: {
+        input_schema: livePhantom,
+        input_schema_source: 'bazaar',
+        input_schema_rejected_sources: [],
+      },
+    },
+    resourceUrl,
+  }), {
+    schema: livePhantom,
+    source: 'live',
+    replaced: false,
+    rejectedSources: [],
+  });
+});
+
+test('fixed-operation sole-field input is not replaced without Bazaar rejection evidence', () => {
+  const liveOneField = {
+    type: 'object',
+    properties: { run: { type: 'boolean' } },
+    required: ['run'],
+    additionalProperties: false,
+  };
+  const enrichmentWithoutCorroboration = {
+    resource: {
+      input_schema: persistedOpenApi,
+      input_schema_source: 'openapi',
+      input_schema_rejected_sources: [],
+    },
+  };
+
+  assert.deepEqual(reconcileHostedCheckInputSchema({
+    liveSchema: liveOneField,
+    enrichment: enrichmentWithoutCorroboration,
+    resourceUrl: 'https://seller.example/v1/reports/report:run',
+  }), {
+    schema: liveOneField,
+    source: 'live',
+    replaced: false,
+    rejectedSources: [],
+  });
+});
+
+test('no persisted DB schema leaves the live schema unchanged', () => {
+  const liveSchema = {
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
+  };
+
+  assert.deepEqual(reconcileHostedCheckInputSchema({
+    liveSchema,
+    enrichment: { resource: { input_schema_source: 'openapi' } },
+    resourceUrl: 'https://seller.example/v1/generate',
+  }), {
+    schema: liveSchema,
+    source: 'live',
+    replaced: false,
+    rejectedSources: [],
+  });
+});
+
+test('missing live schema uses a concrete persisted schema', () => {
+  assert.deepEqual(reconcileHostedCheckInputSchema({
+    liveSchema: undefined,
+    enrichment: persistedEnrichment,
+    resourceUrl: 'https://seller.example/v1/generate',
+  }), {
+    schema: persistedOpenApi,
+    source: 'openapi',
+    replaced: true,
+    rejectedSources: ['bazaar'],
+  });
+});
+
+test('free-form and schema-valued additionalProperties count as concrete persisted inputs', () => {
+  for (const inputSchema of [
+    { type: 'object', properties: {}, additionalProperties: true },
+    { type: 'object', properties: {}, additionalProperties: {} },
+    {
+      type: 'object',
+      properties: {},
+      additionalProperties: { type: 'string' },
+    },
+  ]) {
+    assert.deepEqual(reconcileHostedCheckInputSchema({
+      liveSchema: undefined,
+      enrichment: {
+        resource: {
+          input_schema: inputSchema,
+          input_schema_source: 'openapi',
+          input_schema_rejected_sources: [],
+        },
+      },
+      resourceUrl: 'https://seller.example/v1/free-form',
+    }), {
+      schema: inputSchema,
+      source: 'openapi',
+      replaced: true,
+      rejectedSources: [],
+    });
+  }
+});

--- a/tests/open-check-schema.test.mjs
+++ b/tests/open-check-schema.test.mjs
@@ -158,6 +158,32 @@ test('missing live schema uses a concrete persisted schema', () => {
   });
 });
 
+test('LLM profile and cached Bazaar sources never repair an exact live check schema', () => {
+  const liveClosedEmpty = {
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
+  };
+  for (const inputSchemaSource of ['profile', 'bazaar']) {
+    assert.deepEqual(reconcileHostedCheckInputSchema({
+      liveSchema: liveClosedEmpty,
+      enrichment: {
+        resource: {
+          input_schema: persistedOpenApi,
+          input_schema_source: inputSchemaSource,
+          input_schema_rejected_sources: [],
+        },
+      },
+      resourceUrl: 'https://seller.example/v1/generate',
+    }), {
+      schema: liveClosedEmpty,
+      source: 'live',
+      replaced: false,
+      rejectedSources: [],
+    });
+  }
+});
+
 test('free-form and schema-valued additionalProperties count as concrete persisted inputs', () => {
   for (const inputSchema of [
     { type: 'object', properties: {}, additionalProperties: true },

--- a/tests/open-tool-contracts.test.mjs
+++ b/tests/open-tool-contracts.test.mjs
@@ -102,6 +102,24 @@ test('hosted paid guidance uses one opaque check-fetch-status path', () => {
   assert.doesNotMatch(checkDescription, /prepared seller-route|purchase-mode choices|omit purchase/i);
 });
 
+test('x402_check strict output contract carries reconciled schema provenance', () => {
+  const schema = OPEN_TOOL_CONTRACTS.x402_check.outputSchema;
+  assert.equal(Object.hasOwn(schema.shape, 'inputSchemaSource'), true);
+  assert.equal(Object.hasOwn(schema.shape, 'inputSchemaRejectedSources'), true);
+  assert.equal(schema.safeParse({
+    inputSchema: {
+      type: 'object',
+      properties: { contents: { type: 'array' } },
+    },
+    inputSchemaSource: 'openapi',
+    inputSchemaRejectedSources: ['bazaar'],
+  }).success, true);
+  assert.equal(schema.safeParse({
+    inputSchemaSource: 'openapi',
+    undeclaredSchemaAuthority: true,
+  }).success, false);
+});
+
 test('portfolio top-level output refuses undeclared fields', () => {
   assert.equal(
     OPEN_TOOL_CONTRACTS.dexter_portfolio.outputSchema.safeParse({
@@ -846,6 +864,14 @@ test('real SDK tools/list exposes executable schemas, OAuth, annotations, and me
       }
     }
     if (listed.name === 'x402_check') {
+      assert.equal(
+        Object.hasOwn(listed.outputSchema.properties ?? {}, 'inputSchemaSource'),
+        true,
+      );
+      assert.equal(
+        Object.hasOwn(listed.outputSchema.properties ?? {}, 'inputSchemaRejectedSources'),
+        true,
+      );
       for (const candidateField of [
         'purchaseContractVersion',
         'preparedPayload',


### PR DESCRIPTION
## Summary
- reconcile malformed live x402_check input schemas with richer persisted catalog/OpenAPI truth
- preserve live price, payee, auth, payment option, and opaque-intent evidence
- publish strict schema provenance in the hosted twelve-tool contract and materialized descriptor

## Verification
- 56/56 targeted schema, check-result, strict tool-contract, SDK tools/list, and purchase-contract tests
- node syntax checks and git diff check
