### PR TITLE
fix: bind check schema repair to method

### DIFF
--- a/lib/open-check-result.mjs
+++ b/lib/open-check-result.mjs
@@ -101,6 +101,7 @@ export function buildHostedCheckModelResult({
     liveSchema: publicFields.inputSchema,
     enrichment,
     resourceUrl: url,
+    method: normalizedMethod,
   });
   if (schemaResolution.replaced) {
     publicFields.inputSchema = schemaResolution.schema;

--- a/lib/open-check-schema.mjs
+++ b/lib/open-check-schema.mjs
@@ -6,9 +6,25 @@ function hasOwn(object, key) {
   return isPlainObject(object) && Object.prototype.hasOwnProperty.call(object, key);
 }
 
-function persistedSchemaCandidate(enrichment) {
+function normalizedMethod(value) {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim().toUpperCase()
+    : null;
+}
+
+function persistedSchemaCandidate(enrichment, checkedMethod) {
   const resource = isPlainObject(enrichment?.resource) ? enrichment.resource : null;
   if (!resource || !hasOwn(resource, 'input_schema')) return null;
+
+  // x402_resources is currently URL-unique even though one URL can expose
+  // multiple HTTP methods. URL-only enrichment must therefore never repair a
+  // checked request unless the persisted row represents that exact method.
+  // Missing method identity also fails closed: it cannot corroborate a request
+  // contract for any method.
+  const persistedMethod = normalizedMethod(resource.method);
+  if (!persistedMethod || persistedMethod !== normalizedMethod(checkedMethod)) {
+    return null;
+  }
 
   const schemaSource = typeof resource.input_schema_source === 'string'
     ? resource.input_schema_source.trim()
@@ -103,8 +119,9 @@ export function reconcileHostedCheckInputSchema({
   liveSchema,
   enrichment,
   resourceUrl,
+  method,
 }) {
-  const persisted = persistedSchemaCandidate(enrichment);
+  const persisted = persistedSchemaCandidate(enrichment, method);
   if (!persisted || !schemaHasConcreteInputs(persisted.schema)) {
     return {
       schema: liveSchema,

--- a/tests/open-check-result-contract.test.mjs
+++ b/tests/open-check-result-contract.test.mjs
@@ -147,6 +147,7 @@ test('hosted check repairs only the schema while preserving live quote evidence'
   }];
   const enrichment = {
     resource: {
+      method: 'POST',
       input_schema: persistedSchema,
       input_schema_source: 'openapi',
       input_schema_rejected_sources: ['bazaar'],
@@ -181,6 +182,49 @@ test('hosted check repairs only the schema while preserving live quote evidence'
   assert.equal(structuredContent.authMode, 'paid');
   assert.equal(structuredContent.enrichment, enrichment);
   assert.equal(structuredContent.enrichment_source, 'live_db');
+});
+
+test('hosted check never repairs from a persisted schema for another method', () => {
+  const liveSchema = {
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
+  };
+  const persistedSchema = {
+    type: 'object',
+    properties: { query: { type: 'string' } },
+    required: ['query'],
+    additionalProperties: false,
+  };
+
+  const structuredContent = buildHostedCheckModelResult({
+    checkResult: {
+      requiresPayment: true,
+      statusCode: 402,
+      inputSchema: liveSchema,
+    },
+    url: 'https://seller.example/v1/shared-route',
+    method: 'POST',
+    rawBodyProvided: false,
+    enrichment: {
+      resource: {
+        method: 'GET',
+        input_schema: persistedSchema,
+        input_schema_source: 'openapi',
+        input_schema_rejected_sources: ['bazaar'],
+      },
+      history: [],
+    },
+    enrichmentSource: 'live_db',
+  });
+
+  assert.equal(structuredContent.inputSchema, liveSchema);
+  assert.equal(structuredContent.inputSchemaSource, 'live');
+  assert.equal(structuredContent.checkedRequest.method, 'POST');
+  assert.equal(
+    Object.hasOwn(structuredContent, 'inputSchemaRejectedSources'),
+    false,
+  );
 });
 
 test('hosted check labels an unchanged informative seller schema as live', () => {

--- a/tests/open-check-schema.test.mjs
+++ b/tests/open-check-schema.test.mjs
@@ -14,6 +14,7 @@ const persistedOpenApi = {
 
 const persistedEnrichment = {
   resource: {
+    method: 'post',
     input_schema: persistedOpenApi,
     input_schema_source: 'openapi',
     input_schema_rejected_sources: ['bazaar'],
@@ -32,6 +33,7 @@ test('informative live seller schema remains first', () => {
     liveSchema,
     enrichment: persistedEnrichment,
     resourceUrl: 'https://seller.example/v1/generate',
+    method: 'POST',
   });
 
   assert.equal(resolved.schema, liveSchema);
@@ -52,6 +54,7 @@ test('closed zero-field live schema falls back to richer persisted schema', () =
       liveSchema,
       enrichment: persistedEnrichment,
       resourceUrl: 'https://seller.example/v1/generate',
+      method: 'POST',
     }), {
       schema: persistedOpenApi,
       source: 'openapi',
@@ -74,6 +77,7 @@ test('fixed-operation sole-field phantom falls back only with richer corroborati
     liveSchema: livePhantom,
     enrichment: persistedEnrichment,
     resourceUrl,
+    method: 'POST',
   }), {
     schema: persistedOpenApi,
     source: 'openapi',
@@ -85,12 +89,14 @@ test('fixed-operation sole-field phantom falls back only with richer corroborati
     liveSchema: livePhantom,
     enrichment: {
       resource: {
+        method: 'POST',
         input_schema: livePhantom,
         input_schema_source: 'bazaar',
         input_schema_rejected_sources: [],
       },
     },
     resourceUrl,
+    method: 'POST',
   }), {
     schema: livePhantom,
     source: 'live',
@@ -108,6 +114,7 @@ test('fixed-operation sole-field input is not replaced without Bazaar rejection 
   };
   const enrichmentWithoutCorroboration = {
     resource: {
+      method: 'POST',
       input_schema: persistedOpenApi,
       input_schema_source: 'openapi',
       input_schema_rejected_sources: [],
@@ -118,6 +125,7 @@ test('fixed-operation sole-field input is not replaced without Bazaar rejection 
     liveSchema: liveOneField,
     enrichment: enrichmentWithoutCorroboration,
     resourceUrl: 'https://seller.example/v1/reports/report:run',
+    method: 'POST',
   }), {
     schema: liveOneField,
     source: 'live',
@@ -135,8 +143,9 @@ test('no persisted DB schema leaves the live schema unchanged', () => {
 
   assert.deepEqual(reconcileHostedCheckInputSchema({
     liveSchema,
-    enrichment: { resource: { input_schema_source: 'openapi' } },
+    enrichment: { resource: { method: 'POST', input_schema_source: 'openapi' } },
     resourceUrl: 'https://seller.example/v1/generate',
+    method: 'POST',
   }), {
     schema: liveSchema,
     source: 'live',
@@ -150,6 +159,7 @@ test('missing live schema uses a concrete persisted schema', () => {
     liveSchema: undefined,
     enrichment: persistedEnrichment,
     resourceUrl: 'https://seller.example/v1/generate',
+    method: 'POST',
   }), {
     schema: persistedOpenApi,
     source: 'openapi',
@@ -169,12 +179,14 @@ test('LLM profile and cached Bazaar sources never repair an exact live check sch
       liveSchema: liveClosedEmpty,
       enrichment: {
         resource: {
+          method: 'POST',
           input_schema: persistedOpenApi,
           input_schema_source: inputSchemaSource,
           input_schema_rejected_sources: [],
         },
       },
       resourceUrl: 'https://seller.example/v1/generate',
+      method: 'POST',
     }), {
       schema: liveClosedEmpty,
       source: 'live',
@@ -198,12 +210,14 @@ test('free-form and schema-valued additionalProperties count as concrete persist
       liveSchema: undefined,
       enrichment: {
         resource: {
+          method: 'POST',
           input_schema: inputSchema,
           input_schema_source: 'openapi',
           input_schema_rejected_sources: [],
         },
       },
       resourceUrl: 'https://seller.example/v1/free-form',
+      method: 'POST',
     }), {
       schema: inputSchema,
       source: 'openapi',
@@ -211,4 +225,67 @@ test('free-form and schema-valued additionalProperties count as concrete persist
       rejectedSources: [],
     });
   }
+});
+
+test('URL-only enrichment cannot repair a different checked method', () => {
+  const liveClosedEmpty = {
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
+  };
+
+  for (const persistedMethod of ['GET', 'PATCH']) {
+    assert.deepEqual(reconcileHostedCheckInputSchema({
+      liveSchema: liveClosedEmpty,
+      enrichment: {
+        resource: {
+          ...persistedEnrichment.resource,
+          method: persistedMethod,
+        },
+      },
+      resourceUrl: 'https://seller.example/v1/shared-route',
+      method: 'POST',
+    }), {
+      schema: liveClosedEmpty,
+      source: 'live',
+      replaced: false,
+      rejectedSources: [],
+    });
+  }
+});
+
+test('persisted method identity is required and compared case-insensitively', () => {
+  assert.deepEqual(reconcileHostedCheckInputSchema({
+    liveSchema: undefined,
+    enrichment: {
+      resource: {
+        ...persistedEnrichment.resource,
+        method: ' post ',
+      },
+    },
+    resourceUrl: 'https://seller.example/v1/generate',
+    method: 'POST',
+  }), {
+    schema: persistedOpenApi,
+    source: 'openapi',
+    replaced: true,
+    rejectedSources: ['bazaar'],
+  });
+
+  assert.deepEqual(reconcileHostedCheckInputSchema({
+    liveSchema: undefined,
+    enrichment: {
+      resource: {
+        ...persistedEnrichment.resource,
+        method: undefined,
+      },
+    },
+    resourceUrl: 'https://seller.example/v1/generate',
+    method: 'POST',
+  }), {
+    schema: undefined,
+    source: 'live',
+    replaced: false,
+    rejectedSources: [],
+  });
 });


### PR DESCRIPTION
## Summary
- require persisted resource method to match the checked request method before schema enrichment
- fail closed when method identity is missing or mismatched
- add unit and hosted result contract coverage

## Verification
- 44 focused and tool-contract tests passed
- npm run typecheck:open-release
- npm run build:runtime-workspaces

No production deployment is included.