### PR TITLE
chore: refresh accepted production receipt

### DIFF
--- a/release/open-tool-descriptors.json
+++ b/release/open-tool-descriptors.json
@@ -16,15 +16,15 @@
     },
     "integratedApiRelease": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "58228a1512d55ea1c5a022d31512a898087b1837",
-      "tree": "52988a41a806b00d6cac8cb8ed646076d731231d",
+      "commit": "024caf0652fea0bb56123aaacd5c085e3c21190b",
+      "tree": "631e2b87cda06c53b63b1c4ba421ff3a768ea910",
       "governedContractCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
       "governedContractTree": "b8a3bdd790379f82b959663e679960f213addb5b"
     },
     "portfolioProjection": {
       "repository": "https://github.com/Dexter-DAO/dexter-api",
-      "commit": "58228a1512d55ea1c5a022d31512a898087b1837",
-      "tree": "52988a41a806b00d6cac8cb8ed646076d731231d",
+      "commit": "024caf0652fea0bb56123aaacd5c085e3c21190b",
+      "tree": "631e2b87cda06c53b63b1c4ba421ff3a768ea910",
       "sourcePaths": [
         "src/portfolio/approvedActionTargets.ts",
         "src/routes/passkeyMcpBinding.ts",
@@ -189,7 +189,7 @@
       ],
       "_meta": {
         "ui": {
-          "resourceUri": "ui://dexter/x402-marketplace-search-f219b145",
+          "resourceUri": "ui://dexter/x402-marketplace-search-dbaf2df1",
           "visibility": [
             "model",
             "app"
@@ -209,8 +209,8 @@
           "domain": "https://dexter.cash",
           "prefersBorder": true
         },
-        "ui/resourceUri": "ui://dexter/x402-marketplace-search-f219b145",
-        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-f219b145",
+        "ui/resourceUri": "ui://dexter/x402-marketplace-search-dbaf2df1",
+        "openai/outputTemplate": "ui://dexter/x402-marketplace-search-dbaf2df1",
         "openai/resultCanProduceWidget": true,
         "openai/widgetAccessible": true,
         "openai/widgetDomain": "https://dexter.cash",

--- a/release/opendexter-accepted-production.json
+++ b/release/opendexter-accepted-production.json
@@ -4,12 +4,12 @@
   "api": {
     "endpoint": "https://api.dexter.cash/health",
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "releaseId": "58228a1512d5-9887aa0ff93fa5c5-0c92d24405a6",
-    "sourceCommit": "58228a1512d55ea1c5a022d31512a898087b1837",
-    "sourceTree": "52988a41a806b00d6cac8cb8ed646076d731231d",
-    "toolingCommit": "58228a1512d55ea1c5a022d31512a898087b1837",
-    "artifactSha256": "9887aa0ff93fa5c5253641d1b921d381dab78e5bc32e67920bb7e3750c9c019d",
-    "metadataBindingSha256": "5234fa25f266db1df2c9eb57c4003e7f8acfb38d70e5eb65b73961f9e43d1e77"
+    "releaseId": "024caf0652fe-29bb556896a040a4-f46b9114f838",
+    "sourceCommit": "024caf0652fea0bb56123aaacd5c085e3c21190b",
+    "sourceTree": "631e2b87cda06c53b63b1c4ba421ff3a768ea910",
+    "toolingCommit": "024caf0652fea0bb56123aaacd5c085e3c21190b",
+    "artifactSha256": "29bb556896a040a4903fa32eccc646d7973c1ffc375c35e4e8f3498edeecfe52",
+    "metadataBindingSha256": "49d0434b22dbd3bb4d77a412b9c2b4185c6f86035b2af61c62c31aa11edf288f"
   },
   "facilitator": {
     "endpoint": "https://x402.dexter.cash/version",

--- a/release/opendexter-source-contracts.json
+++ b/release/opendexter-source-contracts.json
@@ -13,15 +13,15 @@
   },
   "integratedApiRelease": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "58228a1512d55ea1c5a022d31512a898087b1837",
-    "tree": "52988a41a806b00d6cac8cb8ed646076d731231d",
+    "commit": "024caf0652fea0bb56123aaacd5c085e3c21190b",
+    "tree": "631e2b87cda06c53b63b1c4ba421ff3a768ea910",
     "governedContractCommit": "c3e32885cc39cdee47eca5a054c0fd7d8a0fdd8b",
     "governedContractTree": "b8a3bdd790379f82b959663e679960f213addb5b"
   },
   "portfolioProjection": {
     "repository": "https://github.com/Dexter-DAO/dexter-api",
-    "commit": "58228a1512d55ea1c5a022d31512a898087b1837",
-    "tree": "52988a41a806b00d6cac8cb8ed646076d731231d",
+    "commit": "024caf0652fea0bb56123aaacd5c085e3c21190b",
+    "tree": "631e2b87cda06c53b63b1c4ba421ff3a768ea910",
     "sourcePaths": [
       "src/portfolio/approvedActionTargets.ts",
       "src/routes/passkeyMcpBinding.ts",


### PR DESCRIPTION
## Summary
- freeze the accepted OpenDexter API identity at immutable release `024caf0652fe-29bb556896a040a4-f46b9114f838`
- retain the current immutable facilitator identity `801547315a59a48fc8dcb4d3e42e40c2ee5ac09e`
- regenerate the source-contract and hosted-tool descriptor derivatives, including the reviewed search widget resource identity

## Verification
- independently fetched the accepted API and facilitator advertisements without redirects
- `node --test tests/open-accepted-production-receipt.test.mjs tests/open-tool-descriptors.test.mjs tests/open-source-contracts.test.mjs tests/open-release-provenance.test.mjs tests/open-check-schema.test.mjs tests/open-check-result-contract.test.mjs tests/x402-search-model.test.mjs tests/x402-search-contract.test.mjs tests/x402-search-degraded-contract.test.mjs` (85 passed)
- `npm run typecheck:open-release`
- `npm run build:apps-sdk:local`

No deployment was performed from this branch.