### PR TITLE
fix: restore x402 core license inventory

### DIFF
--- a/packages/x402-core/LICENSE
+++ b/packages/x402-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dexter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/x402-core-package-inventory.test.mjs
+++ b/tests/x402-core-package-inventory.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packageRoot = path.join(repoRoot, 'packages/x402-core');
+const manifest = JSON.parse(readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
+const licensePath = path.join(packageRoot, 'LICENSE');
+
+const EXPECTED_LICENSE_SHA256 = '6a694c6c736e9474ca4b54dac937a509cc744459e7e7a03aa82a567ab097d7c3';
+const EXPECTED_LICENSE_GIT_BLOB = '769fcf8daffe0842dbd7e29b3b7ab7aad2060dc7';
+
+test('@dexterai/x402-core ships the canonical MIT license promised by its manifest', () => {
+  assert.ok(manifest.files.includes('LICENSE'), 'package manifest must include LICENSE');
+  assert.equal(existsSync(licensePath), true, 'package-local LICENSE must exist');
+
+  const license = readFileSync(licensePath);
+  const sha256 = createHash('sha256').update(license).digest('hex');
+  const gitBlob = createHash('sha1')
+    .update(`blob ${license.length}\0`)
+    .update(license)
+    .digest('hex');
+
+  assert.equal(sha256, EXPECTED_LICENSE_SHA256);
+  assert.equal(gitBlob, EXPECTED_LICENSE_GIT_BLOB);
+});


### PR DESCRIPTION
## Summary
- restore the canonical package-local MIT license promised by `@dexterai/x402-core`
- pin package inventory to the approved SHA-256 and Git blob identities

## Validation
- `node --test tests/x402-core-package-inventory.test.mjs` (1/1 passed)
- `git diff --check HEAD^ HEAD`
- LICENSE: 1063 bytes; SHA-256 `6a694c6c736e9474ca4b54dac937a509cc744459e7e7a03aa82a567ab097d7c3`; Git blob `769fcf8daffe0842dbd7e29b3b7ab7aad2060dc7`
- independent diff review: CLEAR

No package build, pack, publication, release metadata, or runtime action is included.