### PR TITLE
docs: document x402 core package

### DIFF
--- a/packages/x402-core/README.md
+++ b/packages/x402-core/README.md
@@ -1,0 +1,55 @@
+# `@dexterai/x402-core`
+
+Canonical types, formatters, and a search client for the Dexter x402 ecosystem, shared by MCP servers, the SDK, and the ChatGPT widget.
+
+## Requirements
+
+- Node.js 18 or newer
+
+## Install
+
+```sh
+npm install @dexterai/x402-core
+```
+
+## Examples
+
+Search for a capability and format the result for an MCP consumer:
+
+```js
+import {
+  capabilitySearch,
+  buildSearchResponse,
+} from '@dexterai/x402-core';
+
+const result = await capabilitySearch({ query: 'weather data API' });
+const response = buildSearchResponse(result);
+```
+
+Inspect an endpoint's current access and pricing requirements without paying:
+
+```js
+import { checkEndpointPricing } from '@dexterai/x402-core';
+
+async function inspectEndpoint(endpointUrl) {
+  return checkEndpointPricing({ url: endpointUrl, method: 'GET' });
+}
+```
+
+Search and check utilities inspect, discover, and format information. They do not authorize or execute payment. `checkEndpointPricing` sends a live guarded HTTPS request, so a non-GET check may still have provider-side effects.
+
+## Exports
+
+- **Formats and types:** `formatResource`, `formatPrice`, `roundSimilarity`, `formatVolume`, plus raw capability, formatted resource, search, pricing, verification, usage, gaming, and enrichment types.
+- **Capability search:** `capabilitySearch`.
+- **Search response builders:** `buildSearchResponse` and `buildSearchErrorResponse`.
+- **Endpoint pricing and challenge inspection:** `checkEndpointPricing`, `exactAtomicString`, `parsePaymentRequiredHeader`, `sellerAcceptSha256`, `CheckResult`, and `PaymentOption`.
+- **Public URL guard:** `assertPublicExternalUrl`, `createPinnedLookup`, `fetchPublicExternalUrl`, `isPublicIpAddress`, `parseExternalHttpUrl`, and `UnsafeExternalUrlError`.
+- **Bazaar schema extraction:** `extractBazaarSchema` and `BazaarSchema`.
+- **Schema resolution:** `resolveInputSchema`, `resolveOutputSchema`, and their input, output, and source types.
+
+## Project
+
+- [Repository](https://github.com/Dexter-DAO/dexter-mcp)
+- [Homepage](https://dexter.cash)
+- License: MIT

--- a/tests/x402-core-package-inventory.test.mjs
+++ b/tests/x402-core-package-inventory.test.mjs
@@ -9,13 +9,16 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const packageRoot = path.join(repoRoot, 'packages/x402-core');
 const manifest = JSON.parse(readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
 const licensePath = path.join(packageRoot, 'LICENSE');
+const readmePath = path.join(packageRoot, 'README.md');
 
 const EXPECTED_LICENSE_SHA256 = '6a694c6c736e9474ca4b54dac937a509cc744459e7e7a03aa82a567ab097d7c3';
 const EXPECTED_LICENSE_GIT_BLOB = '769fcf8daffe0842dbd7e29b3b7ab7aad2060dc7';
 
-test('@dexterai/x402-core ships the canonical MIT license promised by its manifest', () => {
+test('@dexterai/x402-core ships the package files promised by its manifest', () => {
   assert.ok(manifest.files.includes('LICENSE'), 'package manifest must include LICENSE');
+  assert.ok(manifest.files.includes('README.md'), 'package manifest must include README.md');
   assert.equal(existsSync(licensePath), true, 'package-local LICENSE must exist');
+  assert.equal(existsSync(readmePath), true, 'package-local README.md must exist');
 
   const license = readFileSync(licensePath);
   const sha256 = createHash('sha256').update(license).digest('hex');
@@ -26,4 +29,8 @@ test('@dexterai/x402-core ships the canonical MIT license promised by its manife
 
   assert.equal(sha256, EXPECTED_LICENSE_SHA256);
   assert.equal(gitBlob, EXPECTED_LICENSE_GIT_BLOB);
+
+  const readme = readFileSync(readmePath, 'utf8');
+  assert.ok(readme.trim().length > 0, 'package README.md must be nonempty');
+  assert.match(readme, /@dexterai\/x402-core/, 'package README.md must identify the package');
 });


### PR DESCRIPTION
## Summary
- add the package-local README promised by `@dexterai/x402-core`
- document only the current public exports and payment-authorization boundary
- extend the package inventory test to require both canonical LICENSE and README files

## Validation
- `node --test tests/x402-core-package-inventory.test.mjs`
- `npm run typecheck --workspace @dexterai/x402-core`
- `git diff --check HEAD^ HEAD`
- independent source/API-truth review: CLEAR

No build, pack, publish, release metadata, runtime, database, or payment changes.