### PR TITLE
fix: publish x402 core in both module formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@dexterai/mcp-instructions": "2.4.0",
         "@dexterai/vault": "0.43.0",
         "@dexterai/x402": "^5.4.2",
-        "@dexterai/x402-core": "1.5.1",
+        "@dexterai/x402-core": "1.5.2",
         "@dexterai/x402-mcp-tools": "0.8.0",
         "@dexterai/x402-skills": "file:./packages/x402-skills",
         "@modelcontextprotocol/ext-apps": "1.6.0",
@@ -12761,7 +12761,7 @@
     },
     "packages/x402-core": {
       "name": "@dexterai/x402-core",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@dexterai/mcp-instructions": "2.4.0",
     "@dexterai/vault": "0.43.0",
     "@dexterai/x402": "^5.4.2",
-    "@dexterai/x402-core": "1.5.1",
+    "@dexterai/x402-core": "1.5.2",
     "@dexterai/x402-mcp-tools": "0.8.0",
     "@dexterai/x402-skills": "file:./packages/x402-skills",
     "@modelcontextprotocol/ext-apps": "1.6.0",

--- a/packages/x402-core/package-lock.json
+++ b/packages/x402-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dexterai/x402-core",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dexterai/x402-core",
-      "version": "1.5.0",
+      "version": "1.5.2",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/packages/x402-core/package.json
+++ b/packages/x402-core/package.json
@@ -1,14 +1,16 @@
 {
   "name": "@dexterai/x402-core",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Canonical types, formatters, and search client for the Dexter x402 ecosystem. Shared by all MCP servers, the SDK, and the ChatGPT widget.",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [
@@ -19,7 +21,9 @@
   "scripts": {
     "build": "tsup && tsc --emitDeclarationOnly --outDir dist",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "release:prepare": "npm run typecheck && npm run build && node ./scripts/check-module-formats.mjs",
+    "prepublishOnly": "npm run release:prepare",
+    "release": "npm publish --access public"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/packages/x402-core/scripts/check-module-formats.mjs
+++ b/packages/x402-core/scripts/check-module-formats.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const manifest = JSON.parse(
+  await readFile(resolve(packageRoot, 'package.json'), 'utf8'),
+);
+
+const EXPECTED_RUNTIME_EXPORTS = [
+  'UnsafeExternalUrlError',
+  'assertPublicExternalUrl',
+  'buildSearchErrorResponse',
+  'buildSearchResponse',
+  'capabilitySearch',
+  'checkEndpointPricing',
+  'createPinnedLookup',
+  'exactAtomicString',
+  'extractBazaarSchema',
+  'fetchPublicExternalUrl',
+  'formatPrice',
+  'formatResource',
+  'formatVolume',
+  'isPublicIpAddress',
+  'parseExternalHttpUrl',
+  'parsePaymentRequiredHeader',
+  'resolveInputSchema',
+  'resolveOutputSchema',
+  'roundSimilarity',
+  'sellerAcceptSha256',
+].sort();
+
+function fail(message) {
+  throw new Error(`[check-module-formats] ${message}`);
+}
+
+function packagePath(declaredPath, label) {
+  if (typeof declaredPath !== 'string' || declaredPath.length === 0) {
+    fail(`${label} must declare a nonempty package path`);
+  }
+  const absolute = resolve(packageRoot, declaredPath);
+  if (absolute !== packageRoot && !absolute.startsWith(`${packageRoot}/`)) {
+    fail(`${label} points outside the package: ${declaredPath}`);
+  }
+  return absolute;
+}
+
+async function requireFile(declaredPath, label) {
+  const absolute = packagePath(declaredPath, label);
+  try {
+    if (!(await stat(absolute)).isFile()) {
+      fail(`${label} is not a file: ${declaredPath}`);
+    }
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      fail(`${label} does not exist: ${declaredPath}`);
+    }
+    throw error;
+  }
+  return absolute;
+}
+
+async function walk(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const absolute = resolve(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await walk(absolute));
+    else if (entry.isFile()) files.push(absolute);
+  }
+  return files;
+}
+
+const rootExport = manifest.exports?.['.'];
+if (!rootExport || typeof rootExport !== 'object' || Array.isArray(rootExport)) {
+  fail('exports["."] must declare import, require, and types entrypoints');
+}
+if (manifest.type !== 'module') fail('package type must be "module"');
+
+const mainFile = await requireFile(manifest.main, 'main');
+const moduleFile = await requireFile(manifest.module, 'module');
+const typesFile = await requireFile(manifest.types, 'types');
+const importFile = await requireFile(rootExport.import, 'exports["."].import');
+const requireFilePath = await requireFile(rootExport.require, 'exports["."].require');
+const exportTypesFile = await requireFile(rootExport.types, 'exports["."].types');
+
+if (mainFile !== requireFilePath) {
+  fail('main and exports["."].require must resolve to one CommonJS file');
+}
+if (moduleFile !== importFile) {
+  fail('module and exports["."].import must resolve to one ESM file');
+}
+if (typesFile !== exportTypesFile) {
+  fail('types and exports["."].types must resolve to one declaration file');
+}
+if (!requireFilePath.endsWith('.cjs')) {
+  fail('exports["."].require must resolve to a .cjs file');
+}
+
+const distFiles = await walk(resolve(packageRoot, 'dist'));
+const sourcemaps = distFiles.filter((file) => file.endsWith('.map'));
+if (sourcemaps.length > 0) {
+  fail(`dist must not contain sourcemaps: ${sourcemaps.join(', ')}`);
+}
+
+const esm = await import(manifest.name);
+const cjs = createRequire(import.meta.url)(manifest.name);
+for (const [label, runtime] of [['import', esm], ['require', cjs]]) {
+  const keys = Object.keys(runtime).sort();
+  if (JSON.stringify(keys) !== JSON.stringify(EXPECTED_RUNTIME_EXPORTS)) {
+    fail(`${label} runtime exports differ from the exact public contract: ${keys.join(', ')}`);
+  }
+  for (const name of EXPECTED_RUNTIME_EXPORTS) {
+    if (typeof runtime[name] !== 'function') {
+      fail(`${label} runtime export ${name} must be a function or class`);
+    }
+  }
+  const error = new runtime.UnsafeExternalUrlError('offline module-format check');
+  if (!(error instanceof Error) || error.code !== 'unsafe_external_url') {
+    fail(`${label} UnsafeExternalUrlError does not preserve its public runtime type`);
+  }
+}
+
+const priceInput = 0.0042;
+const esmPrice = esm.formatPrice(priceInput);
+const cjsPrice = cjs.formatPrice(priceInput);
+if (esmPrice !== '$0.0042' || cjsPrice !== esmPrice) {
+  fail('import and require must produce the same canonical pure output');
+}
+
+console.log(
+  `[check-module-formats] import and require expose ${EXPECTED_RUNTIME_EXPORTS.length} matching runtime exports`,
+);

--- a/packages/x402-core/tsup.config.ts
+++ b/packages/x402-core/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: { index: 'src/index.ts' },
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   minify: true,
   clean: true,
   splitting: false,

--- a/tests/x402-core-package-inventory.test.mjs
+++ b/tests/x402-core-package-inventory.test.mjs
@@ -8,8 +8,12 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const packageRoot = path.join(repoRoot, 'packages/x402-core');
 const manifest = JSON.parse(readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
+const packageLock = JSON.parse(readFileSync(path.join(packageRoot, 'package-lock.json'), 'utf8'));
+const rootManifest = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+const rootLock = JSON.parse(readFileSync(path.join(repoRoot, 'package-lock.json'), 'utf8'));
 const licensePath = path.join(packageRoot, 'LICENSE');
 const readmePath = path.join(packageRoot, 'README.md');
+const checkerPath = path.join(packageRoot, 'scripts/check-module-formats.mjs');
 
 const EXPECTED_LICENSE_SHA256 = '6a694c6c736e9474ca4b54dac937a509cc744459e7e7a03aa82a567ab097d7c3';
 const EXPECTED_LICENSE_GIT_BLOB = '769fcf8daffe0842dbd7e29b3b7ab7aad2060dc7';
@@ -33,4 +37,48 @@ test('@dexterai/x402-core ships the package files promised by its manifest', () 
   const readme = readFileSync(readmePath, 'utf8');
   assert.ok(readme.trim().length > 0, 'package README.md must be nonempty');
   assert.match(readme, /@dexterai\/x402-core/, 'package README.md must identify the package');
+});
+
+test('@dexterai/x402-core declares one coherent dual-module release contract', () => {
+  assert.equal(manifest.version, '1.5.2');
+  assert.equal(manifest.type, 'module');
+  assert.equal(manifest.main, 'dist/index.cjs');
+  assert.equal(manifest.module, 'dist/index.js');
+  assert.equal(manifest.types, 'dist/index.d.ts');
+  assert.deepEqual(manifest.exports['.'], {
+    import: './dist/index.js',
+    require: './dist/index.cjs',
+    types: './dist/index.d.ts',
+  });
+  assert.equal(
+    manifest.scripts['release:prepare'],
+    'npm run typecheck && npm run build && node ./scripts/check-module-formats.mjs',
+  );
+  assert.equal(manifest.scripts.prepublishOnly, 'npm run release:prepare');
+  assert.equal(manifest.scripts.release, 'npm publish --access public');
+  assert.doesNotMatch(manifest.scripts.release, /npm version/);
+
+  const tsupConfig = readFileSync(path.join(packageRoot, 'tsup.config.ts'), 'utf8');
+  assert.match(tsupConfig, /format:\s*\['esm',\s*'cjs'\]/);
+  assert.match(tsupConfig, /clean:\s*true/);
+  assert.match(tsupConfig, /sourcemap:\s*false/);
+  assert.equal(existsSync(checkerPath), true, 'module-format checker must exist');
+
+  const checker = readFileSync(checkerPath, 'utf8');
+  assert.match(checker, /createRequire/);
+  assert.match(checker, /await import\(manifest\.name\)/);
+  assert.match(checker, /EXPECTED_RUNTIME_EXPORTS/);
+  assert.match(checker, /endsWith\('\.map'\)/);
+});
+
+test('@dexterai/x402-core source and workspace identities are exactly 1.5.2', () => {
+  assert.equal(packageLock.version, '1.5.2');
+  assert.equal(packageLock.packages[''].version, '1.5.2');
+  assert.equal(rootManifest.dependencies['@dexterai/x402-core'], '1.5.2');
+  assert.equal(rootLock.packages[''].dependencies['@dexterai/x402-core'], '1.5.2');
+  assert.equal(rootLock.packages['packages/x402-core'].version, '1.5.2');
+  assert.deepEqual(rootLock.packages['node_modules/@dexterai/x402-core'], {
+    resolved: 'packages/x402-core',
+    link: true,
+  });
 });


### PR DESCRIPTION
## Product outcome

Restores the CommonJS contract consumed by the published @dexterai/x402 SDK while retaining the existing ESM and TypeScript entrypoints.

## Changes

- publish deterministic ESM and CommonJS builds for @dexterai/x402-core 1.5.2
- add explicit import, require, and types exports with legacy-compatible main/module fields
- make release preparation typecheck, build, and verify both module formats offline
- align the package-local and workspace version identities without registry-integrity fabrication
- extend package inventory tests for module, lifecycle, and lock truth

## Verification

- signed source commit
- release:prepare: typecheck, dual build, 20-export import/require parity
- Node focused suite: 26/26
- core Bazaar Vitest: 5/5
- npm pack --dry-run: ESM, CJS, declarations, README, LICENSE; no sourcemaps
- independent diff review: CLEAR

Publication and installed-package/SDK consumer proof remain separately gated after merge.