### PR TITLE
fix: isolate OpenDexter vault metadata

### DIFF
--- a/http-server-oauth.mjs
+++ b/http-server-oauth.mjs
@@ -23,6 +23,9 @@ import {
 import {
   requireSealedOpenReleaseRuntime,
 } from './lib/open-release-runtime-preflight.mjs';
+import {
+  buildOpenMcpAuthorizationServerMetadata,
+} from './lib/open-tool-auth.mjs';
 
 // Load env from repo root and local MCP overrides
 // Production receives its complete environment from PM2's protected mode-0600
@@ -1122,10 +1125,11 @@ function timingSafeEqualB64(a, b) {
 // OAuth metadata endpoints (served at both root and /mcp/.well-known for compatibility)
 function serveOAuthMetadata(pathname, res, req) {
   writeCors(res);
+  const openMcpAuthorizationServerMetadata =
+    buildOpenMcpAuthorizationServerMetadata(pathname);
   const isAuthMeta = (
     pathname === '/.well-known/oauth-authorization-server' ||
-    pathname === '/mcp/.well-known/oauth-authorization-server' ||
-    pathname === '/.well-known/oauth-authorization-server/mcp'
+    pathname === '/mcp/.well-known/oauth-authorization-server'
   );
   const isProtectedMeta = (
     pathname === '/.well-known/oauth-protected-resource'
@@ -1142,6 +1146,13 @@ function serveOAuthMetadata(pathname, res, req) {
     try { console.log(`[oauth-meta] serve jwks for ${pathname} ua=${req?.headers?.['user-agent']||''}`); } catch {}
     res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control':'no-store' });
     res.end(JSON.stringify({ keys: [rsaPublicJwk] }));
+    return true;
+  }
+
+  if (openMcpAuthorizationServerMetadata) {
+    try { console.log(`[oauth-meta] serve OpenDexter vault metadata for ${pathname} ua=${req?.headers?.['user-agent']||''}`); } catch {}
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control':'no-store' });
+    res.end(JSON.stringify(openMcpAuthorizationServerMetadata));
     return true;
   }
 

--- a/lib/open-tool-auth.mjs
+++ b/lib/open-tool-auth.mjs
@@ -22,6 +22,37 @@ export const OPEN_MCP_PRM = Object.freeze({
   scopes_supported: ['vault'],
 });
 
+/**
+ * Return OpenDexter's dedicated authorization-server metadata only for the
+ * RFC 8414 path-insertion form named by the protected-resource contract.
+ *
+ * The shared root metadata and the legacy `/mcp/.well-known` discovery rail
+ * intentionally remain outside this helper. Keeping the issuer and endpoints
+ * fixed prevents request-host or provider-scope configuration from widening
+ * OpenDexter's single `vault` grant.
+ */
+export function buildOpenMcpAuthorizationServerMetadata(pathname) {
+  if (pathname !== new URL(OPEN_MCP_AUTHORIZATION_SERVER_METADATA).pathname) {
+    return null;
+  }
+
+  return {
+    issuer: OPEN_MCP_AUTHORIZATION_SERVER,
+    authorization_endpoint: `${OPEN_MCP_AUTHORIZATION_SERVER}/authorize`,
+    token_endpoint: `${OPEN_MCP_AUTHORIZATION_SERVER}/token`,
+    registration_endpoint: `${OPEN_MCP_AUTHORIZATION_SERVER}/register`,
+    token_endpoint_auth_methods_supported: [
+      'none',
+      'client_secret_post',
+      'client_secret_basic',
+    ],
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    code_challenge_methods_supported: ['S256'],
+    scopes_supported: ['vault'],
+  };
+}
+
 export function isOpenMcpProtectedResourceMetadataPath(pathname) {
   return pathname === '/.well-known/oauth-protected-resource'
     || pathname === '/.well-known/oauth-protected-resource/mcp';

--- a/tests/open-tool-auth.test.mjs
+++ b/tests/open-tool-auth.test.mjs
@@ -16,6 +16,7 @@ import {
   OPEN_TOOL_SECURITY_SCHEMES,
   VAULT_WWW_AUTHENTICATE,
   assertOpenToolAuthPolicyCoverage,
+  buildOpenMcpAuthorizationServerMetadata,
   buildVaultAuthenticationRequired,
   buildVaultWwwAuthenticate,
   findVaultProtectedToolCall,
@@ -239,6 +240,44 @@ test('resource metadata names the actual authorization-server issuer', () => {
     'error_description',
   ]);
   assert.deepEqual(OPEN_MCP_PRM.scopes_supported, ['vault']);
+});
+
+test('path-inserted OpenDexter authorization metadata is fixed and vault-only', () => {
+  assert.deepEqual(
+    buildOpenMcpAuthorizationServerMetadata(
+      '/.well-known/oauth-authorization-server/mcp',
+    ),
+    {
+      issuer: 'https://mcp.dexter.cash/mcp',
+      authorization_endpoint: 'https://mcp.dexter.cash/mcp/authorize',
+      token_endpoint: 'https://mcp.dexter.cash/mcp/token',
+      registration_endpoint: 'https://mcp.dexter.cash/mcp/register',
+      token_endpoint_auth_methods_supported: [
+        'none',
+        'client_secret_post',
+        'client_secret_basic',
+      ],
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      code_challenge_methods_supported: ['S256'],
+      scopes_supported: ['vault'],
+    },
+  );
+});
+
+test('OpenDexter authorization metadata helper excludes both legacy discovery rails', () => {
+  assert.equal(
+    buildOpenMcpAuthorizationServerMetadata(
+      '/.well-known/oauth-authorization-server',
+    ),
+    null,
+  );
+  assert.equal(
+    buildOpenMcpAuthorizationServerMetadata(
+      '/mcp/.well-known/oauth-authorization-server',
+    ),
+    null,
+  );
 });
 
 test('both protected-resource metadata routes serve the same corrected issuer', () => {


### PR DESCRIPTION
## Summary
- serve vault-only authorization-server metadata at the exact RFC 8414 path-inserted OpenDexter URI
- bind issuer and OAuth endpoints to the existing mcp.dexter.cash/mcp authorization server
- leave root legacy metadata and the /mcp/.well-known Supabase discovery rail unchanged

## Verification
- node --test tests/open-tool-auth.test.mjs tests/open-mcp-manifest.test.mjs (20/20)
- node --check http-server-oauth.mjs
- git diff --check

No deployment is included.