### PR TITLE
fix: reconcile OpenDexter Gate 0 release train

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
         "packages/*"
       ],
       "dependencies": {
-        "@dexterai/mcp-instructions": "2.4.0",
+        "@dexterai/mcp-instructions": "2.4.1",
         "@dexterai/vault": "0.43.0",
         "@dexterai/x402": "^5.4.2",
         "@dexterai/x402-core": "1.5.2",
-        "@dexterai/x402-mcp-tools": "0.8.0",
+        "@dexterai/x402-mcp-tools": "0.8.2",
         "@dexterai/x402-skills": "file:./packages/x402-skills",
         "@modelcontextprotocol/ext-apps": "1.6.0",
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@dexterai/mcp-instructions": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@dexterai/mcp-instructions/-/mcp-instructions-2.4.0.tgz",
-      "integrity": "sha512-ABM/8sQ11JhsF+h6I9swhRHcAZXFng9nUjl5h12MTbmQmoC5uGTmTDWszDumUBgZaq8C1PpRQ4Xu7tzUVIGJNA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dexterai/mcp-instructions/-/mcp-instructions-2.4.1.tgz",
+      "integrity": "sha512-oqeDqHB76YghgP5434rwFJiqa7ArzIHeUtH4P5cmYQGwle6OS2tvbdxNEu/2lH0FZlbjdo0jbYRYesoe9rLUoA==",
       "license": "MIT"
     },
     "node_modules/@dexterai/vault": {
@@ -493,14 +493,14 @@
       "link": true
     },
     "node_modules/@dexterai/x402-mcp-tools": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402-mcp-tools/-/x402-mcp-tools-0.8.0.tgz",
-      "integrity": "sha512-XrwUxdx68ykweSyMaihtyQUjKJj9FLor90MeLG27id5AdW25fZ9SxYfIN9ju+vcxTsAvRdeqaLvqLV3sxIkWkA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402-mcp-tools/-/x402-mcp-tools-0.8.2.tgz",
+      "integrity": "sha512-W93dxp/edX6LOYTcQdcOUWp5h1gi63HUeTDMD6UWNPc7F0jePn607/4ThH5hVdCfMlxihE9f5+5QyiO7wU1xqg==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/dextercard": "^0.5.0",
         "@dexterai/x402": "^5.4.2",
-        "@dexterai/x402-core": "^1.5.0",
+        "@dexterai/x402-core": "1.5.2",
         "@modelcontextprotocol/sdk": "^1.17.4",
         "@x402/core": "^2.6.0",
         "@x402/extensions": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "deploy:mcp": "npm run verify:release:runtime && npm run verify:release:installed && node scripts/release/activate-open-release.mjs"
   },
   "dependencies": {
-    "@dexterai/mcp-instructions": "2.4.0",
+    "@dexterai/mcp-instructions": "2.4.1",
     "@dexterai/vault": "0.43.0",
     "@dexterai/x402": "^5.4.2",
     "@dexterai/x402-core": "1.5.2",
-    "@dexterai/x402-mcp-tools": "0.8.0",
+    "@dexterai/x402-mcp-tools": "0.8.2",
     "@dexterai/x402-skills": "file:./packages/x402-skills",
     "@modelcontextprotocol/ext-apps": "1.6.0",
     "@modelcontextprotocol/sdk": "1.29.0",

--- a/release/opendexter-dependency-train.json
+++ b/release/opendexter-dependency-train.json
@@ -9,20 +9,20 @@
   "repositories": {
     "hosted": {
       "remote": "https://github.com/Dexter-DAO/dexter-mcp.git",
-      "provenanceCommit": "fa094ce79f67b539bd74fc7ab6a52822398a085b"
+      "provenanceCommit": "fb2753f7e9f1e7503d3c61572787decf52499a76"
     },
     "opendexter-ide": {
       "remote": "https://github.com/Dexter-DAO/opendexter-ide.git",
-      "provenanceCommit": "3c2ed36736f6f637dedd05c890e6e2d49d869794",
+      "provenanceCommit": "5e7f4a2b7523ba32101346906ce61d5ad8497e47",
       "rootWorkspaceBuild": {
-        "packageLockSha256": "c096945c6d6e74c36be532ed747746df254c2aa16e7b5eec2a909a8c2e959b60",
+        "packageLockSha256": "841b0dbe9e6120f75de6b52c947dcf23e3805e7ed4fc8513847b85a369ffe0bb",
         "buildOrder": [
           {
-            "workspace": "@dexterai/dextercard",
+            "workspace": "@dexterai/mcp-instructions",
             "script": "build"
           },
           {
-            "workspace": "@dexterai/mcp-instructions",
+            "workspace": "@dexterai/dextercard",
             "script": "build"
           },
           {
@@ -40,12 +40,12 @@
   "sourcePackages": [
     {
       "name": "@dexterai/x402-core",
-      "version": "1.5.0",
-      "rootSpecifier": "1.5.0",
+      "version": "1.5.2",
+      "rootSpecifier": "1.5.2",
       "source": "hosted",
       "path": "packages/x402-core",
       "entrypoint": "dist/index.js",
-      "treeHash": "d524b6f42c847bd2479fb8ebc41b02d0705410ad",
+      "treeHash": "1d6d241da3cb38072b8afff012e50e45f84c90f3",
       "install": {
         "source": "workspace",
         "release": "workspace"
@@ -53,21 +53,21 @@
     },
     {
       "name": "@dexterai/mcp-instructions",
-      "version": "2.4.0",
-      "rootSpecifier": "2.4.0",
+      "version": "2.4.1",
+      "rootSpecifier": "2.4.1",
       "source": "opendexter-ide",
       "path": "packages/mcp-instructions",
       "entrypoint": "dist/index.js",
-      "treeHash": "9c17a942c7393875cca685c06e7b8bcb80a011eb",
+      "treeHash": "626d5c3f283f8af7db692139def511b3e4c7d655",
       "packedArtifact": {
         "buildMode": "root-workspace",
         "buildScript": "build",
-        "integrity": "sha512-ABM/8sQ11JhsF+h6I9swhRHcAZXFng9nUjl5h12MTbmQmoC5uGTmTDWszDumUBgZaq8C1PpRQ4Xu7tzUVIGJNA==",
-        "shasum": "6cc035584d9e0fc4e060924543a5bc7ec412f1ce",
-        "size": 10951,
-        "unpackedSize": 44282,
-        "entryCount": 5,
-        "tgzSha256": "95a2ff1758345da22263e903fa3137a2e46d3f816523c8e286bf742ca25adeb8"
+        "integrity": "sha512-oqeDqHB76YghgP5434rwFJiqa7ArzIHeUtH4P5cmYQGwle6OS2tvbdxNEu/2lH0FZlbjdo0jbYRYesoe9rLUoA==",
+        "shasum": "1963daf5263698c192e68b30dfba8ed830ea568b",
+        "size": 11797,
+        "unpackedSize": 46073,
+        "entryCount": 6,
+        "tgzSha256": "c89d5d9bfa5254cbdd641a73c2dc9499446e3c635b024b192ec309a9500d1a3c"
       },
       "install": {
         "source": "linked-source",
@@ -76,21 +76,21 @@
     },
     {
       "name": "@dexterai/x402-mcp-tools",
-      "version": "0.8.0",
-      "rootSpecifier": "0.8.0",
+      "version": "0.8.2",
+      "rootSpecifier": "0.8.2",
       "source": "opendexter-ide",
       "path": "packages/x402-mcp-tools",
       "entrypoint": "dist/index.js",
-      "treeHash": "266beeb8deaab7f05bc06d929252d2e22c0ec6e8",
+      "treeHash": "872ebf952522e3c6648dda240e1b6eace4024f2c",
       "packedArtifact": {
         "buildMode": "root-workspace",
         "buildScript": "build",
-        "integrity": "sha512-XrwUxdx68ykweSyMaihtyQUjKJj9FLor90MeLG27id5AdW25fZ9SxYfIN9ju+vcxTsAvRdeqaLvqLV3sxIkWkA==",
-        "shasum": "3ed48da3ba121644c3a48e472d5413cc41a8136b",
-        "size": 58407,
-        "unpackedSize": 232025,
-        "entryCount": 19,
-        "tgzSha256": "f2d35bb5827b123b9b3456c45b08891f15b47f35db04020b2e2bdd05925db2fc"
+        "integrity": "sha512-W93dxp/edX6LOYTcQdcOUWp5h1gi63HUeTDMD6UWNPc7F0jePn607/4ThH5hVdCfMlxihE9f5+5QyiO7wU1xqg==",
+        "shasum": "a2a49980e5dd1171929a338716a3fb440eb216d4",
+        "size": 65151,
+        "unpackedSize": 265411,
+        "entryCount": 20,
+        "tgzSha256": "7236ad530969773a1b86d6557b681db302cdb9efe4813a7a1354a7704307a767"
       },
       "install": {
         "source": "linked-source",

--- a/scripts/verify-open-release-dependencies.mjs
+++ b/scripts/verify-open-release-dependencies.mjs
@@ -11,6 +11,7 @@ import {
   readFile,
   realpath,
   rm,
+  writeFile,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, dirname, resolve } from 'node:path';
@@ -22,6 +23,9 @@ import {
   reviewedNpmInvocation,
   reviewedReleaseToolEnvironment,
 } from '../lib/open-release-tooling.mjs';
+import {
+  reviewedSourceContractRemoteRefs,
+} from './materialize-open-tool-descriptors.mjs';
 
 const execFileAsync = promisify(execFile);
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -115,15 +119,109 @@ async function remoteAdvertisesCommit(
   remote,
   commit,
 ) {
-  const refs = await reviewedGitRemoteRefs({
-    remote,
-    runCommand,
-    environment,
-  });
+  const anonymousHome = await mkdtemp(
+    resolve(tmpdir(), 'opendexter-anonymous-remote-'),
+  );
+  const anonymousAskpass = resolve(anonymousHome, 'askpass.sh');
+  let refs;
+  try {
+    await writeFile(
+      anonymousAskpass,
+      '#!/bin/sh\nexit 1\n',
+      { flag: 'wx', mode: 0o700 },
+    );
+    try {
+      refs = await reviewedGitRemoteRefs({
+        remote,
+        runCommand: hardenedRemoteRefsRunner(runCommand, {
+          HOME: anonymousHome,
+          GIT_ASKPASS: anonymousAskpass,
+          GIT_ASKPASS_REQUIRE: 'force',
+          GIT_TERMINAL_PROMPT: '0',
+        }),
+        environment: {
+          ...environment,
+          HOME: anonymousHome,
+        },
+      });
+    } catch (anonymousError) {
+      const token = environment?.GITHUB_PERSONAL_ACCESS_TOKEN
+        || environment?.GH_TOKEN;
+      if (
+        !token
+        || !isCanonicalCredentialFreeGitHubRemote(remote)
+      ) {
+        throw anonymousError;
+      }
+      try {
+        refs = await reviewedSourceContractRemoteRefs({
+          remote,
+          runCommand: hardenedRemoteRefsRunner(runCommand),
+          environment,
+        });
+      } catch (authenticatedError) {
+        if (
+          authenticatedError?.message
+          === 'OpenDexter private source token is invalid'
+        ) {
+          throw authenticatedError;
+        }
+        throw new Error('authenticated GitHub source lookup failed', {
+          cause: authenticatedError,
+        });
+      }
+    }
+  } finally {
+    await rm(anonymousHome, { recursive: true, force: true });
+  }
   return refs.split(/\r?\n/).some((line) => {
     const [remoteCommit, refname, extra] = line.trim().split(/\s+/);
     return remoteCommit === commit && Boolean(refname) && extra === undefined;
   });
+}
+
+function hardenedRemoteRefsRunner(runCommand, environmentOverrides = {}) {
+  return async (command, args, options = {}) => {
+    if (command !== 'git' || !args.includes('ls-remote')) {
+      return runCommand(command, args, options);
+    }
+    const commandIndex = args.indexOf('ls-remote');
+    return runCommand(command, [
+      ...args.slice(0, commandIndex),
+      ...(args.includes('credential.helper=')
+        ? []
+        : ['-c', 'credential.helper=']),
+      '-c', 'http.followRedirects=false',
+      ...args.slice(commandIndex),
+    ], {
+      ...options,
+      env: {
+        ...options.env,
+        ...environmentOverrides,
+      },
+    });
+  };
+}
+
+function isCanonicalCredentialFreeGitHubRemote(remote) {
+  if (typeof remote !== 'string') return false;
+  let parsed;
+  try {
+    parsed = new URL(remote);
+  } catch {
+    return false;
+  }
+  return parsed.toString() === remote
+    && parsed.protocol === 'https:'
+    && parsed.hostname === 'github.com'
+    && parsed.port === ''
+    && parsed.username === ''
+    && parsed.password === ''
+    && parsed.search === ''
+    && parsed.hash === ''
+    && /^\/[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9._-]+\.git$/.test(
+      parsed.pathname,
+    );
 }
 
 export function gitTreeSpec(commit, packagePath) {

--- a/tests/open-mcp-manifest.test.mjs
+++ b/tests/open-mcp-manifest.test.mjs
@@ -9,8 +9,11 @@ import {
 } from '../lib/open-tool-contracts.mjs';
 import {
   OPEN_MCP_AUTHORIZATION_SERVER,
+  OPEN_MCP_AUTHORIZATION_SERVER_METADATA,
+  OPEN_MCP_PRM,
   OPEN_MCP_PRM_URL,
   OPEN_MCP_VAULT_AUDIENCE,
+  buildOpenMcpAuthorizationServerMetadata,
 } from '../lib/open-tool-auth.mjs';
 
 test('well-known manifest is generated from the five-to-twelve OAuth contract', () => {
@@ -20,6 +23,13 @@ test('well-known manifest is generated from the five-to-twelve OAuth contract', 
   assert.equal(manifest.url, OPEN_MCP_VAULT_AUDIENCE);
   assert.equal(manifest.auth.protectedResourceMetadata, OPEN_MCP_PRM_URL);
   assert.equal(manifest.auth.authorizationServer, OPEN_MCP_AUTHORIZATION_SERVER);
+  assert.deepEqual(OPEN_MCP_PRM.scopes_supported, ['vault']);
+  assert.deepEqual(
+    buildOpenMcpAuthorizationServerMetadata(
+      new URL(OPEN_MCP_AUTHORIZATION_SERVER_METADATA).pathname,
+    ).scopes_supported,
+    ['vault'],
+  );
   assert.deepEqual(manifest.auth.protectedTools, [
     'x402_fetch',
     'x402_status',
@@ -68,11 +78,11 @@ test('manifest, server identity, and package use one release version', async () 
   assert.equal(packageJson.engines.node, '^20.19.0 || >=22.12.0');
   assert.equal(
     packageJson.dependencies['@dexterai/mcp-instructions'],
-    '2.4.0',
+    '2.4.1',
   );
   assert.equal(
     packageJson.dependencies['@dexterai/x402-mcp-tools'],
-    '0.8.0',
+    '0.8.2',
   );
   assert.equal(
     packageJson.dependencies['@modelcontextprotocol/sdk'],

--- a/tests/open-release-dependencies.test.mjs
+++ b/tests/open-release-dependencies.test.mjs
@@ -3,6 +3,7 @@ import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
   access,
+  lstat,
   mkdir,
   mkdtemp,
   readFile,
@@ -65,6 +66,11 @@ function advertisedOriginRunner(
     }
     return execFileAsync(command, args, options);
   };
+}
+
+async function useFixtureRemote(fixture, remote) {
+  await git(fixture.repositoryRoot, 'remote', 'set-url', 'origin', remote);
+  return { ...fixture.repository, remote };
 }
 
 async function packedSourceFixture({ lifecycleHook } = {}) {
@@ -290,7 +296,7 @@ async function registryLockFixture(mutator = () => {}) {
     },
     'packages/x402-core': {
       name: '@dexterai/x402-core',
-      version: '1.5.0',
+      version: '1.5.2',
     },
   };
   for (const expected of [
@@ -357,9 +363,9 @@ test('hosted source declares one exact internal dependency train', async () => {
   assert.deepEqual(
     manifest.sourcePackages.map(({ name, version }) => `${name}@${version}`),
     [
-      '@dexterai/x402-core@1.5.0',
-      '@dexterai/mcp-instructions@2.4.0',
-      '@dexterai/x402-mcp-tools@0.8.0',
+      '@dexterai/x402-core@1.5.2',
+      '@dexterai/mcp-instructions@2.4.1',
+      '@dexterai/x402-mcp-tools@0.8.2',
       '@dexterai/vault@0.43.0',
     ],
   );
@@ -375,6 +381,10 @@ test('hosted source declares one exact internal dependency train', async () => {
   assert.equal(manifest.schemaVersion, 2);
   assert.equal(manifest.packageManager, 'npm@10.9.3');
   assert.equal(manifest.node, '^20.19.0 || >=22.12.0');
+  assert.deepEqual(manifest.repositories.hosted, {
+    remote: 'https://github.com/Dexter-DAO/dexter-mcp.git',
+    provenanceCommit: 'fb2753f7e9f1e7503d3c61572787decf52499a76',
+  });
   assert.deepEqual(
     manifest.sourcePackages.map(({ install }) => install),
     [
@@ -386,13 +396,13 @@ test('hosted source declares one exact internal dependency train', async () => {
   );
   assert.deepEqual(manifest.repositories['opendexter-ide'], {
     remote: 'https://github.com/Dexter-DAO/opendexter-ide.git',
-    provenanceCommit: '3c2ed36736f6f637dedd05c890e6e2d49d869794',
+    provenanceCommit: '5e7f4a2b7523ba32101346906ce61d5ad8497e47',
     rootWorkspaceBuild: {
       packageLockSha256:
-        'c096945c6d6e74c36be532ed747746df254c2aa16e7b5eec2a909a8c2e959b60',
+        '841b0dbe9e6120f75de6b52c947dcf23e3805e7ed4fc8513847b85a369ffe0bb',
       buildOrder: [
-        { workspace: '@dexterai/dextercard', script: 'build' },
         { workspace: '@dexterai/mcp-instructions', script: 'build' },
+        { workspace: '@dexterai/dextercard', script: 'build' },
         { workspace: '@dexterai/x402-mcp-tools', script: 'build' },
       ],
     },
@@ -400,11 +410,11 @@ test('hosted source declares one exact internal dependency train', async () => {
   for (const [name, tgzSha256] of [
     [
       '@dexterai/mcp-instructions',
-      '95a2ff1758345da22263e903fa3137a2e46d3f816523c8e286bf742ca25adeb8',
+      'c89d5d9bfa5254cbdd641a73c2dc9499446e3c635b024b192ec309a9500d1a3c',
     ],
     [
       '@dexterai/x402-mcp-tools',
-      'f2d35bb5827b123b9b3456c45b08891f15b47f35db04020b2e2bdd05925db2fc',
+      '7236ad530969773a1b86d6557b681db302cdb9efe4813a7a1354a7704307a767',
     ],
   ]) {
     const artifact = manifest.sourcePackages.find(
@@ -490,7 +500,7 @@ test('registry lock accepts the hosted workspace and exact registry packages', a
 test('registry lock rejects a registry copy of the hosted workspace', async () => {
   const fixture = await registryLockFixture((lock) => {
     lock.packages['node_modules/@dexterai/x402-core'] = {
-      version: '1.5.0',
+      version: '1.5.2',
       resolved: 'https://registry.example/x402-core.tgz',
       integrity: 'sha512-fixture',
     };
@@ -709,6 +719,327 @@ test('source preflight requires a reachable origin advertising the exact provena
       unreachable.join('\n'),
       /cannot verify Git provenance: fixture origin unavailable/,
     );
+  } finally {
+    await rm(fixture.repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('source preflight stays anonymous for public remotes even when an ambient token exists', async () => {
+  const fixture = await packedSourceFixture();
+  const token = 'ambient-token-must-not-reach-anonymous-git';
+  const calls = [];
+  const ambientHome = await mkdtemp(resolve(tmpdir(), 'ambient-home-'));
+  let anonymousHome;
+  let anonymousAskpass;
+  let anonymousAskpassMode;
+  let anonymousAskpassBytes;
+  try {
+    const runner = advertisedOriginRunner(fixture.repositoryRoot, { calls });
+    const issues = await inspectPackageSourcePreflight(
+      fixture.repositoryRoot,
+      fixture.expected,
+      fixture.repository,
+      {
+        requireBuild: true,
+        environment: { HOME: ambientHome, GH_TOKEN: token },
+        runCommand: async (command, args, options = {}) => {
+          if (command === 'git' && args.includes('ls-remote')) {
+            anonymousHome = options.env.HOME;
+            anonymousAskpass = options.env.GIT_ASKPASS;
+            anonymousAskpassBytes = await readFile(anonymousAskpass, 'utf8');
+            anonymousAskpassMode = (await lstat(anonymousAskpass)).mode & 0o777;
+          }
+          return runner(command, args, options);
+        },
+      },
+    );
+    assert.deepEqual(issues, []);
+    const remoteCalls = calls.filter(
+      ({ command, args }) => command === 'git' && args.includes('ls-remote'),
+    );
+    assert.equal(remoteCalls.length, 1);
+    assert.equal(Object.hasOwn(remoteCalls[0].options.env, 'GH_TOKEN'), false);
+    assert.equal(
+      Object.hasOwn(
+        remoteCalls[0].options.env,
+        'GITHUB_PERSONAL_ACCESS_TOKEN',
+      ),
+      false,
+    );
+    assert.equal(
+      Object.hasOwn(
+        remoteCalls[0].options.env,
+        'OPENDEXTER_PRIVATE_GIT_TOKEN',
+      ),
+      false,
+    );
+    assert.equal(JSON.stringify(remoteCalls[0].args).includes(token), false);
+    assert.equal(remoteCalls[0].args.includes('credential.helper='), true);
+    assert.equal(remoteCalls[0].args.includes('http.followRedirects=false'), true);
+    assert.equal(anonymousHome, remoteCalls[0].options.env.HOME);
+    assert.equal(anonymousAskpass, remoteCalls[0].options.env.GIT_ASKPASS);
+    assert.notEqual(anonymousHome, ambientHome);
+    assert.equal(remoteCalls[0].options.env.GIT_TERMINAL_PROMPT, '0');
+    assert.equal(remoteCalls[0].options.env.GIT_ASKPASS_REQUIRE, 'force');
+    assert.equal(anonymousAskpassBytes, '#!/bin/sh\nexit 1\n');
+    assert.equal(anonymousAskpassMode, 0o700);
+    await assert.rejects(access(anonymousHome));
+    await assert.rejects(access(anonymousAskpass));
+  } finally {
+    await rm(fixture.repositoryRoot, { recursive: true, force: true });
+    await rm(ambientHome, { recursive: true, force: true });
+  }
+});
+
+test('source preflight retries one canonical private GitHub remote through isolated askpass', async () => {
+  const fixture = await packedSourceFixture();
+  const remote = 'https://github.com/Dexter-DAO/private-source-fixture.git';
+  const token = 'private-token-that-must-never-enter-diagnostics';
+  const tokenSha256 = createHash('sha256').update(token).digest('hex');
+  let remoteLookups = 0;
+  let askpassPath;
+  let anonymousHome;
+  let anonymousAskpass;
+  try {
+    const repository = await useFixtureRemote(fixture, remote);
+    const issues = await inspectPackageSourcePreflight(
+      fixture.repositoryRoot,
+      fixture.expected,
+      repository,
+      {
+        requireBuild: true,
+        environment: {
+          HOME: '/tmp',
+          GITHUB_PERSONAL_ACCESS_TOKEN: token,
+          GH_TOKEN: 'lower-priority-token',
+        },
+        runCommand: async (command, args, options = {}) => {
+          if (command === 'git' && args.includes('ls-remote')) {
+            remoteLookups += 1;
+            assert.equal(JSON.stringify(args).includes(token), false);
+            assert.equal(args.includes('http.followRedirects=false'), true);
+            assert.equal(args.includes('credential.helper='), true);
+            if (remoteLookups === 1) {
+              assert.equal(Object.hasOwn(options.env, 'GH_TOKEN'), false);
+              assert.equal(
+                Object.hasOwn(options.env, 'GITHUB_PERSONAL_ACCESS_TOKEN'),
+                false,
+              );
+              anonymousHome = options.env.HOME;
+              anonymousAskpass = options.env.GIT_ASKPASS;
+              assert.notEqual(anonymousHome, '/tmp');
+              assert.equal(options.env.GIT_TERMINAL_PROMPT, '0');
+              assert.equal(options.env.GIT_ASKPASS_REQUIRE, 'force');
+              assert.equal(
+                await readFile(anonymousAskpass, 'utf8'),
+                '#!/bin/sh\nexit 1\n',
+              );
+              assert.equal(
+                (await lstat(anonymousAskpass)).mode & 0o777,
+                0o700,
+              );
+              throw new Error('anonymous source is private');
+            }
+            assert.equal(remoteLookups, 2);
+            assert.equal(args.includes('--git-dir=/dev/null'), true);
+            assert.equal(args.includes('credential.helper='), true);
+            assert.equal(args.includes('--refs'), true);
+            assert.deepEqual(args.slice(-3), [
+              remote,
+              'refs/heads/*',
+              'refs/tags/*',
+            ]);
+            assert.equal(options.env.GIT_CONFIG_GLOBAL, '/dev/null');
+            assert.equal(options.env.GIT_CONFIG_NOSYSTEM, '1');
+            assert.equal(options.env.GIT_TERMINAL_PROMPT, '0');
+            assert.equal(options.env.GIT_ASKPASS_REQUIRE, 'force');
+            assert.equal(Object.hasOwn(options.env, 'GH_TOKEN'), false);
+            assert.equal(
+              Object.hasOwn(options.env, 'GITHUB_PERSONAL_ACCESS_TOKEN'),
+              false,
+            );
+            assert.equal(
+              createHash('sha256')
+                .update(options.env.OPENDEXTER_PRIVATE_GIT_TOKEN)
+                .digest('hex'),
+              tokenSha256,
+            );
+            askpassPath = options.env.GIT_ASKPASS;
+            const helper = await readFile(askpassPath, 'utf8');
+            assert.equal(helper.includes(token), false);
+            assert.equal(helper.includes('extraHeader'), false);
+            return {
+              stdout: `${repository.provenanceCommit}\trefs/heads/main\n`,
+              stderr: '',
+            };
+          }
+          return execFileAsync(command, args, options);
+        },
+      },
+    );
+    assert.deepEqual(issues, []);
+    assert.equal(remoteLookups, 2);
+    assert.equal(typeof askpassPath, 'string');
+    await assert.rejects(access(askpassPath));
+    await assert.rejects(access(anonymousAskpass));
+    await assert.rejects(access(anonymousHome));
+    assert.equal(issues.join('\n').includes(token), false);
+  } finally {
+    await rm(fixture.repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('authenticated source lookup refuses redirects without a third credential contact', async () => {
+  const fixture = await packedSourceFixture();
+  const remote = 'https://github.com/Dexter-DAO/private-source-fixture.git';
+  const token = 'private-token-that-must-not-follow-a-redirect';
+  let remoteLookups = 0;
+  try {
+    const repository = await useFixtureRemote(fixture, remote);
+    const issues = await inspectPackageSourcePreflight(
+      fixture.repositoryRoot,
+      fixture.expected,
+      repository,
+      {
+        requireBuild: true,
+        environment: { HOME: '/tmp', GH_TOKEN: token },
+        runCommand: async (command, args, options = {}) => {
+          if (command === 'git' && args.includes('ls-remote')) {
+            remoteLookups += 1;
+            assert.equal(args.includes('http.followRedirects=false'), true);
+            if (remoteLookups === 1) {
+              throw new Error('anonymous source is private');
+            }
+            assert.equal(remoteLookups, 2);
+            assert.equal(
+              createHash('sha256')
+                .update(options.env.OPENDEXTER_PRIVATE_GIT_TOKEN)
+                .digest('hex'),
+              createHash('sha256').update(token).digest('hex'),
+            );
+            throw new Error(`redirect target echoed ${token}`);
+          }
+          return execFileAsync(command, args, options);
+        },
+      },
+    );
+    assert.equal(remoteLookups, 2);
+    assert.match(
+      issues.join('\n'),
+      /cannot verify Git provenance: authenticated GitHub source lookup failed/,
+    );
+    assert.doesNotMatch(issues.join('\n'), /private-token/);
+  } finally {
+    await rm(fixture.repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('source preflight never retries authentication for noncanonical remotes', async () => {
+  const remotes = [
+    'git@github.com:Dexter-DAO/private-source-fixture.git',
+    'https://example.test/private-source-fixture.git',
+    'https://user@github.com/Dexter-DAO/private-source-fixture.git',
+    'https://github.com.evil.example/Dexter-DAO/private-source-fixture.git',
+    'https://github.com/Dexter-DAO/private-source-fixture',
+    'https://github.com/Dexter-DAO/private-source-fixture.git?redirect=1',
+  ];
+  for (const remote of remotes) {
+    const fixture = await packedSourceFixture();
+    let remoteLookups = 0;
+    try {
+      const repository = await useFixtureRemote(fixture, remote);
+      const issues = await inspectPackageSourcePreflight(
+        fixture.repositoryRoot,
+        fixture.expected,
+        repository,
+        {
+          requireBuild: true,
+          environment: { HOME: '/tmp', GH_TOKEN: 'unused-private-token' },
+          runCommand: async (command, args, options = {}) => {
+            if (command === 'git' && args.includes('ls-remote')) {
+              remoteLookups += 1;
+              throw new Error('anonymous source is unavailable');
+            }
+            return execFileAsync(command, args, options);
+          },
+        },
+      );
+      assert.equal(remoteLookups, 1);
+      assert.match(
+        issues.join('\n'),
+        /cannot verify Git provenance: anonymous source is unavailable/,
+      );
+      assert.doesNotMatch(issues.join('\n'), /unused-private-token/);
+    } finally {
+      await rm(fixture.repositoryRoot, { recursive: true, force: true });
+    }
+  }
+});
+
+test('source preflight rejects a malformed private token before authenticated contact', async () => {
+  const fixture = await packedSourceFixture();
+  const remote = 'https://github.com/Dexter-DAO/private-source-fixture.git';
+  let remoteLookups = 0;
+  try {
+    const repository = await useFixtureRemote(fixture, remote);
+    const issues = await inspectPackageSourcePreflight(
+      fixture.repositoryRoot,
+      fixture.expected,
+      repository,
+      {
+        requireBuild: true,
+        environment: { HOME: '/tmp', GH_TOKEN: 'hostile\nsecond-line' },
+        runCommand: async (command, args, options = {}) => {
+          if (command === 'git' && args.includes('ls-remote')) {
+            remoteLookups += 1;
+            throw new Error('anonymous source is private');
+          }
+          return execFileAsync(command, args, options);
+        },
+      },
+    );
+    assert.equal(remoteLookups, 1);
+    assert.match(issues.join('\n'), /private source token is invalid/);
+    assert.doesNotMatch(issues.join('\n'), /hostile|second-line/);
+  } finally {
+    await rm(fixture.repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('authenticated source lookup retains the exact advertised-commit predicate', async () => {
+  const fixture = await packedSourceFixture();
+  const remote = 'https://github.com/Dexter-DAO/private-source-fixture.git';
+  let remoteLookups = 0;
+  try {
+    const repository = await useFixtureRemote(fixture, remote);
+    const issues = await inspectPackageSourcePreflight(
+      fixture.repositoryRoot,
+      fixture.expected,
+      repository,
+      {
+        requireBuild: true,
+        environment: { HOME: '/tmp', GH_TOKEN: 'private-token' },
+        runCommand: async (command, args, options = {}) => {
+          if (command === 'git' && args.includes('ls-remote')) {
+            remoteLookups += 1;
+            if (remoteLookups === 1) {
+              throw new Error('anonymous source is private');
+            }
+            return {
+              stdout: `${'f'.repeat(40)}\trefs/heads/main\n`,
+              stderr: '',
+            };
+          }
+          return execFileAsync(command, args, options);
+        },
+      },
+    );
+    assert.equal(remoteLookups, 2);
+    assert.match(
+      issues.join('\n'),
+      /canonical origin does not advertise provenance commit/,
+    );
+    assert.doesNotMatch(issues.join('\n'), /private-token/);
   } finally {
     await rm(fixture.repositoryRoot, { recursive: true, force: true });
   }

--- a/tests/open-skill-resources.test.mjs
+++ b/tests/open-skill-resources.test.mjs
@@ -112,7 +112,7 @@ test('served guidance requires native OAuth and bounded nonretryable spending', 
 
 test('generated runtime instructions contain only native OAuth wallet guidance', () => {
   const runtime = buildOpenServerInstructions();
-  assert.equal(SERVER_INSTRUCTIONS_VERSION, '2.4.0');
+  assert.equal(SERVER_INSTRUCTIONS_VERSION, '2.4.1');
   assert.doesNotMatch(runtime, /\b(?:setup|enroll) link\b|\brelay(?:ing|ed|s)?\b/i);
   assert.match(runtime, /host show its native OpenDexter Connect action/i);
   assert.match(runtime, /dexter_portfolio/);


### PR DESCRIPTION
## What changed

- reconcile the hosted OpenDexter dependency train to `@dexterai/mcp-instructions@2.4.1`, `@dexterai/x402-core@1.5.2`, and `@dexterai/x402-mcp-tools@0.8.2`
- bind the train to the current Gate-0 MCP and OpenDexter source provenance
- harden private source verification so public lookups stay anonymous and canonical private GitHub retries use isolated, nonredirecting askpass transport
- freeze package, lock, manifest, and skill-resource truth in focused tests

## Why

Gate-0 runtime activation must not proceed from a source tree whose dependency train and immutable registry receipts disagree. The prior verifier also inherited ambient anonymous Git credentials and allowed authenticated redirect following; this change removes both leakage paths without weakening exact advertised-ref provenance.

## Validation

- focused Gate-0 tests: 37 passed, 1 intentional skip
- complete open-release suite: 124 passed, 1 intentional skip
- broad `open-*` suite: 302 passed, 1 intentional skip
- `verify:release:lock`
- `verify:release:source` against exact IDE, Vault SDK, API, and facilitator source roots
- fresh exact-source `npm ci`, Studio setup, runtime workspace build, typecheck, Apps SDK build, and installed-runtime verification
- `git diff --check` and independent review: no P0-P3 findings