### PR TITLE
feat: gate skill-catalog integrity in CI

### DIFF
--- a/.github/workflows/ci-skill-integrity.yml
+++ b/.github/workflows/ci-skill-integrity.yml
@@ -1,0 +1,89 @@
+name: ci-skill-integrity
+
+# Capability-integrity gate for the skill catalog.
+#
+# skills-lock.json records where a skill came from (source repo + a one-time
+# hash) but is not regenerated or checked anywhere, so a skill edited AFTER
+# admission (a "rug pull": an added exfil endpoint) passes silently — and four
+# of the five skills in the catalog have no entry at all.
+#
+# eyebrow closes that gap WITHOUT becoming a noisy gate. eyebrowlock.json
+# fingerprints every skills/<slug>/SKILL.md (including the symlinked pay skill
+# and its .claude/skills view, plus AGENTS.md): a canonical content hash over
+# the whole skill directory AND its declared egress (the hosts it reaches from
+# curl / wget / WebFetch call lines). Per eyebrow.policy.json this job fails
+# only when an artifact, relative to the lockfile:
+#   - gains new reach (a new egress host), or
+#   - introduces a new CRITICAL finding.
+# A skill's wording can change freely (allowContentDrift) — prose edits are
+# reported but do not fail the build. That is deliberate: this repo edits its
+# skills routinely, and gating on every byte would get the gate disabled,
+# exactly like an over-broad scanner. Today every skill's egress set is empty,
+# which makes the gate maximally sensitive in the direction that matters: ANY
+# first network endpoint appearing on a call line trips it.
+#
+# Scope, stated honestly: the egress parser is line-based and host-granular. A
+# URL split across lines, assembled from shell vars, or a new PATH on an
+# already-listed host is not caught here — that is reviewer territory. This
+# gate is defense-in-depth for the common shape (a new endpoint appearing on a
+# call line), not a parser of everything bash can do.
+#
+# Refresh the lockfile when a skill legitimately changes its reach:
+#   eyebrow scan --path . --lockfile eyebrowlock.json
+# and commit eyebrowlock.json in the same PR. The diff on that file is the
+# audit trail of what changed and who approved it. See docs/skill-integrity.md.
+#
+# The action is pinned by commit SHA (immutable); the `version` input selects
+# the eyebrow release to install, and the published checksums guard download
+# integrity in transit. eyebrow.policy.json is picked up automatically (the
+# action's default --policy path).
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - '.agents/skills/**'
+      - '.claude/skills/**'
+      - 'AGENTS.md'
+      - 'eyebrowlock.json'
+      - 'eyebrow.policy.json'
+      - '.github/workflows/ci-skill-integrity.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - '.agents/skills/**'
+      - '.claude/skills/**'
+      - 'AGENTS.md'
+      - 'eyebrowlock.json'
+      - 'eyebrow.policy.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # A skill added without regenerating the lockfile would otherwise be
+      # silently ungated (drift is advisory by policy, and a brand-new skill
+      # has no baseline to expand against). This makes coverage itself a hard
+      # gate.
+      - name: lockfile covers every skill
+        run: |
+          missing=0
+          for f in skills/*/SKILL.md; do
+            slug=$(basename "$(dirname "$f")")
+            grep -q "\"discoveredFrom\": \"skills/$slug/SKILL.md\"" eyebrowlock.json || {
+              echo "::error::skills/$slug has no eyebrowlock.json entry — run: eyebrow scan --path . --lockfile eyebrowlock.json and commit the result"
+              missing=1
+            }
+          done
+          exit "$missing"
+      - name: eyebrow verify (drift / rug-pull gate)
+        uses: alexverify/eyebrow/action@b2cebcb8bdd555b5f64ba9bf43a4c7bbb59b112b # v0.4.2
+        with:
+          version: v0.4.2
+          path: .
+          lockfile: eyebrowlock.json

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ env-change-notes.md
 
 # Studio prompts (contain sensitive info)
 toolsets/studio/prompts/
+
+# eyebrow local snapshot cache (content-addressed; not committed)
+.eyebrow/

--- a/docs/skill-integrity.md
+++ b/docs/skill-integrity.md
@@ -1,0 +1,94 @@
+# Skill capability integrity
+
+dexter-mcp ships five agent-facing skills (`skills/<slug>/SKILL.md`) plus the
+repo-level `AGENTS.md` conventions file. Today one mechanism tracks them:
+
+- **`skills-lock.json`** — records *where* a skill came from (`source`,
+  `sourceType`) plus a one-time content hash. It covers one of the five skills
+  (`pay`), and nothing regenerates or verifies it.
+
+So a skill edited **after** admission — an added exfiltration endpoint, a new
+credentialed call — passes every existing check silently. For a payments MCP
+server, that post-admission edit is the classic supply-chain **rug pull**, and
+the blast radius is an agent that authorizes money movement.
+
+`ci-skill-integrity` closes that gap with [eyebrow](https://github.com/alexverify/eyebrow),
+a content-addressed integrity engine — and does it **without** becoming a gate
+that fires on every edit.
+
+## What it gates on (and what it deliberately doesn't)
+
+`eyebrowlock.json` fingerprints every skill in the catalog — including the
+symlinked `skills/pay` (single source at `.agents/skills/pay`, also exposed at
+`.claude/skills/pay`) and `AGENTS.md`: a canonical content hash over the whole
+skill directory (references included) **and** its declared egress — the set of
+hosts the skill reaches from a network-call line (`curl`, `wget`, `WebFetch`).
+On every PR that touches a skill, the
+[`ci-skill-integrity`](../.github/workflows/ci-skill-integrity.yml) workflow
+re-derives that fingerprint and, per [`eyebrow.policy.json`](../eyebrow.policy.json),
+fails the build **only** when an artifact:
+
+- **gains a new egress host** vs the lockfile (`failOnCapabilityExpansion`), or
+- introduces a **new critical finding** (`failOnSeverity: critical`).
+
+It **does not** fail on a skill's wording changing (`allowContentDrift: true`).
+Prose edits, refactors, and doc updates that keep the same reach are *reported*
+but pass. This is deliberate: these skills are edited routinely, and a gate
+that fired on every byte would be forced off within a week.
+
+One property specific to this catalog makes the gate unusually sharp: **every
+skill's egress set is currently empty** — the skills instruct agents to call
+MCP tools, not raw endpoints. So *any* first URL appearing on a call line in
+any skill trips the gate. There is no allowlist to hide inside.
+
+**Scope, honestly:** the egress parser is line-based and host-granular. It
+catches the common rug-pull shape — a new endpoint appearing on a call line.
+It does **not** catch a URL split across lines, one assembled from shell
+variables, or a new *path* on an already-listed host; those remain reviewer
+territory. Treat this gate as defense-in-depth, not a bash parser.
+
+This **complements** `skills-lock.json` — provenance (where a skill came from)
+stays there; integrity (whether it changed, and whether its reach grew) lives
+in `eyebrowlock.json`, regenerated and enforced on every relevant PR.
+
+## Recorded baseline findings
+
+`eyebrow scan` also runs static analysis, and the lockfile records the current
+findings as the accepted baseline — the gate fails only on **new** critical
+findings, so these do not fail builds:
+
+- `skills/opendexter/SKILL.md` — three high-severity pattern matches
+  (PROMPT-INJECTION ×2, WALLET-THEFT ×1). All three match **protective**
+  text: the skill's own rules forbidding exposure of bearer tokens, private
+  keys, and seed phrases, and its instruction-confirmation policy. The
+  patterns flag the vocabulary, not misbehavior — the same false-positive
+  shape eyebrow documents for guardrail passages.
+- `AGENTS.md` — one high-severity SENSITIVE-PATH-READ match, again on a
+  protective classification passage.
+
+If a future edit introduces a *new* critical finding, the gate fails; anything
+below stays advisory and visible in the eyebrow output.
+
+## Refreshing the lockfile
+
+When a skill legitimately changes its reach, regenerate the fingerprint in the
+**same PR**:
+
+```bash
+# one-time: install eyebrow (see github.com/alexverify/eyebrow/releases)
+eyebrow scan --path . --lockfile eyebrowlock.json
+git add eyebrowlock.json
+```
+
+The diff on `eyebrowlock.json` shows exactly which skill's reach changed,
+reviewed alongside the skill change itself. A skill that adds a new egress
+host with no matching lockfile update is what the gate rejects. A skill added
+without any lockfile entry is rejected by the coverage step before eyebrow
+even runs.
+
+## Scope
+
+v1 fingerprints the first-party skill catalog and `AGENTS.md`: content hash +
+network egress. Exec and filesystem capabilities, lockfile signing, and a
+findings threshold below critical can be layered on later purely in
+`eyebrow.policy.json`, without changing this workflow.

--- a/eyebrow.policy.json
+++ b/eyebrow.policy.json
@@ -1,0 +1,5 @@
+{
+  "failOnCapabilityExpansion": true,
+  "allowContentDrift": true,
+  "failOnSeverity": "critical"
+}

--- a/eyebrowlock.json
+++ b/eyebrowlock.json
@@ -1,0 +1,175 @@
+{
+  "version": 1,
+  "generatedAt": "2026-08-05T21:16:07.067346Z",
+  "generator": "eyebrow/v0.4.2",
+  "artifacts": [
+    {
+      "id": "052a0f0ab6a69960",
+      "tool": "claude-code",
+      "scope": "project:.",
+      "type": "skill",
+      "name": "pay",
+      "source": {
+        "kind": "local",
+        "ref": ".claude/skills/pay"
+      },
+      "capabilities": {},
+      "contentHash": "sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "discoveredFrom": ".claude/skills/pay/SKILL.md"
+    },
+    {
+      "id": "106dd1d6a5376797",
+      "tool": "skills-lock",
+      "scope": "project:.",
+      "type": "skill",
+      "name": "x402-debugging",
+      "source": {
+        "kind": "local",
+        "ref": "skills/x402-debugging"
+      },
+      "capabilities": {},
+      "files": [
+        {
+          "path": "SKILL.md",
+          "hash": "158bf3fe29c92536dfc9db60131052b58d279b59b36ad171c9bd1fd73351119a"
+        }
+      ],
+      "contentHash": "sha256-1e095d409c05b2ce33478f4bcb97494d4dcbb4c9a148ec3126f7ebaa075ceae4",
+      "discoveredFrom": "skills/x402-debugging/SKILL.md"
+    },
+    {
+      "id": "5f1f22e473c30a33",
+      "tool": "codex",
+      "scope": "project:.",
+      "type": "context",
+      "name": "AGENTS",
+      "source": {
+        "kind": "local",
+        "ref": "AGENTS.md"
+      },
+      "capabilities": {},
+      "files": [
+        {
+          "path": "AGENTS.md",
+          "hash": "4f3c3a97a15c8a100926503cee44faa6a1dbc078085cbbe9f87982619c0368e8"
+        }
+      ],
+      "findings": [
+        {
+          "ruleId": "SENSITIVE-PATH-READ",
+          "severity": "high",
+          "owasp": "ASK-06",
+          "file": "AGENTS.md",
+          "line": 85,
+          "snippet": "HARNESS_COOKIE in repos (.env)",
+          "explanation": "references sensitive credential or secret paths"
+        }
+      ],
+      "contentHash": "sha256-1f59dd9b0daf4f7003a4a2a88a3f54f4c76bddc95d80dfeba514015955e54982",
+      "discoveredFrom": "AGENTS.md"
+    },
+    {
+      "id": "635f885ed26ca50f",
+      "tool": "skills-lock",
+      "scope": "project:.",
+      "type": "skill",
+      "name": "dexter-mcp",
+      "source": {
+        "kind": "local",
+        "ref": "skills/dexter-mcp"
+      },
+      "capabilities": {},
+      "files": [
+        {
+          "path": "SKILL.md",
+          "hash": "2ff39b3dc37385dba813aebacfb671a6a8e107f530d41f9a63f33bf3d505f7c2"
+        }
+      ],
+      "contentHash": "sha256-c842876cefc9d4b520204a14ff620c3a5e802a71174d34fb79d1a6c861865881",
+      "discoveredFrom": "skills/dexter-mcp/SKILL.md"
+    },
+    {
+      "id": "89a1942c63d2d64d",
+      "tool": "skills-lock",
+      "scope": "project:.",
+      "type": "skill",
+      "name": "pay",
+      "source": {
+        "kind": "local",
+        "ref": "skills/pay"
+      },
+      "capabilities": {},
+      "contentHash": "sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "discoveredFrom": "skills/pay/SKILL.md"
+    },
+    {
+      "id": "d1e038cb1ee9286f",
+      "tool": "skills-lock",
+      "scope": "project:.",
+      "type": "skill",
+      "name": "x402-protocol",
+      "source": {
+        "kind": "local",
+        "ref": "skills/x402-protocol"
+      },
+      "capabilities": {},
+      "files": [
+        {
+          "path": "SKILL.md",
+          "hash": "50226aa9d4f88d92afccde86a61468adfa9e28d58a7d0fdd418a50944d4c65ed"
+        }
+      ],
+      "contentHash": "sha256-67c9966340b5a79a956551a499942d449ba2913056c78437b9eeceee2022c72f",
+      "discoveredFrom": "skills/x402-protocol/SKILL.md"
+    },
+    {
+      "id": "e984ae9ccf160153",
+      "tool": "skills-lock",
+      "scope": "project:.",
+      "type": "skill",
+      "name": "opendexter",
+      "source": {
+        "kind": "local",
+        "ref": "skills/opendexter"
+      },
+      "capabilities": {},
+      "files": [
+        {
+          "path": "SKILL.md",
+          "hash": "0b90a439559eb44ed5a6a58845d0adc5837165b64714bb4ecfe79987ecca7d25"
+        }
+      ],
+      "findings": [
+        {
+          "ruleId": "PROMPT-INJECTION",
+          "severity": "high",
+          "owasp": "ASK-07",
+          "file": "SKILL.md",
+          "line": 74,
+          "snippet": "it already does, do not ask for another approval; otherwise request only the",
+          "explanation": "contains consent-bypass or prompt-injection language"
+        },
+        {
+          "ruleId": "PROMPT-INJECTION",
+          "severity": "high",
+          "owasp": "ASK-07",
+          "file": "SKILL.md",
+          "line": 92,
+          "snippet": "concerns under the same checked request and ceiling. Do not ask the user to",
+          "explanation": "contains consent-bypass or prompt-injection language"
+        },
+        {
+          "ruleId": "WALLET-THEFT",
+          "severity": "high",
+          "owasp": "ASK-06",
+          "file": "SKILL.md",
+          "line": 181,
+          "snippet": "passkey material, private keys, seed phrases, or private upload paths.",
+          "explanation": "references cryptocurrency wallet or seed-phrase material"
+        }
+      ],
+      "contentHash": "sha256-f46f7759c0626dceca5af5f67491893c2fbc0e872faa68b0ecb521733e7fb286",
+      "discoveredFrom": "skills/opendexter/SKILL.md"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

This adds a CI gate that does two things for every skill in the catalog:

- **Hashes each skill.** `eyebrowlock.json` commits a content fingerprint of every skill directory (all five, including the symlinked `pay`, plus `AGENTS.md`). If a skill is edited after approval, the change shows up, and the lockfile diff is the audit trail of who approved what.
- **Verifies each skill.** Static analysis scans skill content for malicious shapes (prompt injection, wallet/seed-phrase theft, secret exfiltration) and records each skill's network egress. On every PR touching a skill, the gate fails if a skill gains a **new egress host** or a **new critical finding**.

Prose edits never fail the build (`allowContentDrift: true` in `eyebrow.policy.json`), this repo edits its skills routinely, and a gate that fires on every wording change gets disabled. Only reach and new criticals block.

Files: `.github/workflows/ci-skill-integrity.yml`, `eyebrowlock.json`, `eyebrow.policy.json`, `docs/skill-integrity.md`, one `.gitignore` stanza.

## Why

These skills instruct agents how to authorize USDC payments. A skill edited *after* admission, an added exfil or payment endpoint, is the classic supply-chain rug pull, and today it passes silently: `skills-lock.json` covers one of five skills, hashes a single file, and nothing verifies it. This PR adds the integrity half; provenance stays in `skills-lock.json`.

The gate is sharp precisely because every skill's egress set is currently **empty**, skills route agents to MCP tools, not raw endpoints. The first URL appearing on any call line in any skill fails the build; routine editing never does.

The lockfile records four pre-existing findings as the accepted baseline (3 in `skills/opendexter`, 1 in `AGENTS.md`). All four match the skills' own *protective* guardrail text ("never expose bearer tokens / seed phrases"), not misbehavior, explained in `docs/skill-integrity.md`.

## What eyebrow is

[eyebrow](https://github.com/alexverify/eyebrow) is an open-source single static Go binary for supply-chain integrity of AI-agent artifacts: it fingerprints skills into a content-addressed lockfile, statically analyzes them, and fails CI only on the committed policy. Zero runtime dependencies. The same integration gates the skill catalog in Aeon: [aeonfun/aeon](https://github.com/aeonfun/aeon/pull/815)

[v0.4.2](https://github.com/alexverify/eyebrow/releases/tag/v0.4.2) was released for this PR with support for this repo's layout: `skills-lock.json`-managed catalogs (the same convention `solana-foundation/pay` uses) and symlinked skill directories. The workflow pins the release by immutable commit SHA.

## Validation

- `eyebrow verify --ci --path . --lockfile eyebrowlock.json` → exit 0 on this branch
- coverage step: 5/5 skills covered; a fake uncovered skill fails the step with an `::error` naming the slug (negative test, then removed)
- workflow YAML parses; `permissions: contents: read`; triggers scoped to skill/lockfile/policy paths only — no coupling to the release train

No deployment is included. Removing the gate is deleting three files.
